### PR TITLE
expanding BclConvert class to include all summary reports

### DIFF
--- a/src/agr/seq/bclconvert.py
+++ b/src/agr/seq/bclconvert.py
@@ -32,6 +32,22 @@ class BclConvert:
         return os.path.join(self._out_dir, "Reports", "Top_Unknown_Barcodes.csv")
 
     @property
+    def adapter_metrics(self) -> str:
+        return os.path.join(self._out_dir, "Reports", "Adapter_Metrics.csv")
+
+    @property
+    def demultiplex_stats(self) -> str:
+        return os.path.join(self._out_dir, "Reports", "Demultiplex_Stats.csv")
+
+    @property
+    def quality_metrics(self) -> str:
+        return os.path.join(self._out_dir, "Reports", "Quality_Metrics.csv")
+
+    @property
+    def run_info_xml(self) -> str:
+        return os.path.join(self._out_dir, "Reports", "RunInfo.xml")
+
+    @property
     def fastq_complete_path(self) -> str:
         return os.path.join(self._log_dir, "FastqComplete.txt")
 


### PR DESCRIPTION
I've added additionally properties to the BclConvert class which include all the summary reports generated by bclconvert that MultiQC consumes.