### PR TITLE
Extending KgdOutput class and adding unblind tasks

### DIFF
--- a/src/agr/redun/tasks/__init__.py
+++ b/src/agr/redun/tasks/__init__.py
@@ -31,6 +31,7 @@ from .tassel3 import (
     tbt_to_map_info,
     map_info_to_hap_map,
 )
+from .unblind import unblind_one, unblind_all, get_unblind_script
 
 __all__ = [
     "bam_stats_one",
@@ -74,4 +75,8 @@ __all__ = [
     "tag_pair_to_tbt",
     "tbt_to_map_info",
     "map_info_to_hap_map",
+    # Unblind:
+    "unblind_one",
+    "unblind_all",
+    "get_unblind_script"
 ]

--- a/src/agr/redun/tasks/kgd.py
+++ b/src/agr/redun/tasks/kgd.py
@@ -10,6 +10,20 @@ logger = logging.getLogger(__name__)
 # keys for files, not filenames
 KGD_SAMPLE_STATS = "sample-stats"
 KGD_GUSBASE_RDATA = "gusbase-rdata"
+GHW05_CSV = "ghw05-csv"
+GHW05_VCF = "ghw05-vcf"
+GHW05_INBREEDING_CSV = "ghw05-inbreeding-csv"
+GHW05_LONG_CSV = "ghw05-long-csv"
+GHW05_PC_CSV = "ghw05-pc-csv"
+GHW05_PCA_METADATA_TSV = "ghw05-pca-metadata-tsv"
+GHW05_PCA_VECTORS_TSV = "ghw05-pca-vectors-tsv"
+HEATMAP_ORDER_HWDGM05_CSV = "heatmap-order-hwdgm05-csv"
+HIGH_RELATEDNESS_CSV = "high-relatedness-csv"
+HIGH_RELATENESS_SPLIT_CSV = "high-relateness-split-csv"
+SEQ_ID_CSV = "seq-id-csv"
+SAMPLE_STATS_RAW_CSV = "sample-stats-raw-csv"
+SAMPLE_STATS_RAW_COMBINED_CSV = "sample-stats-raw-combined-csv"
+KGD_STDOUT = "kgd-stdout"
 
 KGD_TOOL_NAME = "KGD"
 
@@ -44,6 +58,26 @@ def _kgd_job_spec(
         expected_paths={
             KGD_SAMPLE_STATS: os.path.join(out_dir, "SampleStats.csv"),
             KGD_GUSBASE_RDATA: os.path.join(out_dir, "GUSbase.RData"),
+            GHW05_CSV: os.path.join(out_dir, "GHW05.csv"),
+            GHW05_VCF: os.path.join(out_dir, "GHW05.vcf"),
+            GHW05_INBREEDING_CSV: os.path.join(out_dir, "GHW05-Inbreeding.csv"),
+            GHW05_LONG_CSV: os.path.join(out_dir, "GHW05-long.csv"),
+            GHW05_PC_CSV: os.path.join(out_dir, "GHW05-PC.csv"),
+            GHW05_PCA_METADATA_TSV: os.path.join(out_dir, "GHW05-pca_metadata.tsv"),
+            GHW05_PCA_VECTORS_TSV: os.path.join(out_dir, "GHW05-pca_vectors.tsv"),
+            HEATMAP_ORDER_HWDGM05_CSV: os.path.join(
+                out_dir, "HeatmapOrderHWdgm.05.csv"
+            ),
+            HIGH_RELATEDNESS_CSV: os.path.join(out_dir, "HighRelatedness.csv"),
+            HIGH_RELATENESS_SPLIT_CSV: os.path.join(
+                out_dir, "HighRelatedness.split.csv"
+            ),
+            SEQ_ID_CSV: os.path.join(out_dir, "seqID.csv"),
+            SAMPLE_STATS_RAW_CSV: os.path.join(out_dir, "SampleStatsRaw.csv"),
+            SAMPLE_STATS_RAW_COMBINED_CSV: os.path.join(
+                out_dir, "SampleStatsRawCombined.csv"
+            ),
+            KGD_STDOUT: out_path,
         },
         expected_globs={},
     )
@@ -53,6 +87,25 @@ def _kgd_job_spec(
 class KgdOutput:
     sample_stats_csv: File
     gusbase_rdata: File
+    ghw05_csv: File
+    ghw05_vcf: File
+    ghw05_inbreeding_csv: File
+    ghw05_long_csv: File
+    ghw05_PC_csv: File
+    ghw05_pca_metadata_tsv: File
+    ghw05_pca_vectors_tsv: File
+    heatmap_order_hwdgm05_csv: File
+    high_relatedness_csv: File
+    high_relateness_split_csv: File
+    seq_ID_csv: File
+    sample_stats_raw_csv: File
+    sample_stats_raw_combined_csv: File
+    kgd_stdout: File
+
+
+def kgd_output_files(kgd_output: KgdOutput) -> list[File]:
+    """Return all output as a list of files."""
+    return [file for file in vars(kgd_output).values()]
 
 
 @task()
@@ -84,4 +137,24 @@ def kgd(work_dir: str, genotyping_method: str, hap_map_files: list[File]) -> Kgd
     return KgdOutput(
         sample_stats_csv=result_files.expected_files[KGD_SAMPLE_STATS],
         gusbase_rdata=result_files.expected_files[KGD_GUSBASE_RDATA],
+        ghw05_csv=result_files.expected_files[GHW05_CSV],
+        ghw05_vcf=result_files.expected_files[GHW05_VCF],
+        ghw05_inbreeding_csv=result_files.expected_files[GHW05_INBREEDING_CSV],
+        ghw05_long_csv=result_files.expected_files[GHW05_LONG_CSV],
+        ghw05_PC_csv=result_files.expected_files[GHW05_PC_CSV],
+        ghw05_pca_metadata_tsv=result_files.expected_files[GHW05_PCA_METADATA_TSV],
+        ghw05_pca_vectors_tsv=result_files.expected_files[GHW05_PCA_VECTORS_TSV],
+        heatmap_order_hwdgm05_csv=result_files.expected_files[
+            HEATMAP_ORDER_HWDGM05_CSV
+        ],
+        high_relatedness_csv=result_files.expected_files[HIGH_RELATEDNESS_CSV],
+        high_relateness_split_csv=result_files.expected_files[
+            HIGH_RELATENESS_SPLIT_CSV
+        ],
+        seq_ID_csv=result_files.expected_files[SEQ_ID_CSV],
+        sample_stats_raw_csv=result_files.expected_files[SAMPLE_STATS_RAW_CSV],
+        sample_stats_raw_combined_csv=result_files.expected_files[
+            SAMPLE_STATS_RAW_COMBINED_CSV
+        ],
+        kgd_stdout=result_files.expected_files[KGD_STDOUT],
     )

--- a/src/agr/redun/tasks/unblind.py
+++ b/src/agr/redun/tasks/unblind.py
@@ -1,0 +1,89 @@
+"""This module replaces qc_sampleids with sampleid using GQuery derived sed scripts"""
+
+import logging
+import os.path
+from redun import task, File
+from agr.redun import one_forall
+from agr.util.subprocess import run_catching_stderr
+from agr.gquery import GQuery, Predicates
+
+logger = logging.getLogger(__name__)
+
+
+
+@task
+def get_unblind_script(
+        out_dir: str,
+        flowcell_id: str,
+        enzyme: str,
+        gbs_cohort: str,
+        library: str
+        ) -> File:
+    """
+    Get the unblind script for cohort using GQuery.
+    """
+
+    out_path = os.path.join(out_dir, f"{library}.all.{gbs_cohort}.{enzyme}.unblind.sed")
+
+    with open(out_path, "w") as out_f:
+        GQuery(
+            task="gbs_keyfile",
+            badge_type="library",
+            predicates=Predicates(
+                flowcell=flowcell_id,
+                enzyme=enzyme,
+                gbs_cohort=gbs_cohort,
+                unblinding=True,
+                columns="qc_sampleid,sample",
+                noheading=True,
+            ),
+            items=[library],
+            outfile=out_f,
+        ).run()
+    return File(out_path)
+
+
+@task()
+def unblind_one(  
+     blinded_file: File,
+     unblind_script: File,
+     out_dir: str,
+     ) -> File:
+    """
+    Unblind a single result file.
+    """
+
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, os.path.basename(blinded_file.path))
+    
+    with open(out_path, "w") as out_f:
+        run_catching_stderr(
+            [
+                "sed", 
+                "-f", 
+                unblind_script.path, 
+                blinded_file.path
+            ],
+            stdout=out_f, 
+            check=True       
+        )
+    return File(out_path)
+
+
+@task()
+def unblind_all(  
+     blinded_files: list[File],
+     unblind_script: File,
+     out_dir: str,
+     ) -> list[File]:
+    """
+    Unblind a list of result files.
+    """
+    return one_forall(
+        task=unblind_one, 
+        items=blinded_files, 
+        unblind_script=unblind_script, 
+        out_dir=out_dir
+        )
+
+


### PR DESCRIPTION
updating the naming convention for the sed script

updating sytnax for consistency

extending the KGD class to track all needed files

attempting to collect KGD output Files as a list of Files for unblind_all

removing list comprehension from unblind_all parameters

attempting to track KGDstdout

reverting the KGD stdout and stderr log paths

debuggin list comprehension for kgd_unblind

Fix KGD blinded files list using lazy_map

Redun lazy expressions means that inline list comprehensions don't work.  See e.g. other uses of lazy_map.