### PR TITLE
Bclconvert patch to remove --force and shifted stdout and stderr out of the untouchable bclconvert out_dir

### DIFF
--- a/src/agr/redun/tasks/fake_bcl_convert.py
+++ b/src/agr/redun/tasks/fake_bcl_convert.py
@@ -22,7 +22,6 @@ def fake_bcl_convert(
     in_dir: str, sample_sheet_path: str, out_dir: str, n_reads
 ) -> BclConvertOutput:
     paths = BclConvertPaths(out_dir)
-    paths.create_directories()
 
     # find the real run
     run_name = os.path.basename(in_dir)

--- a/src/agr/redun/tasks/sample_sheet.py
+++ b/src/agr/redun/tasks/sample_sheet.py
@@ -1,4 +1,6 @@
 import logging
+import os.path
+
 from dataclasses import dataclass
 from redun import task, File
 
@@ -23,6 +25,10 @@ def cook_sample_sheet(
     impute_lanes=[1, 2],
 ) -> CookSampleSheetOutput:
     """Process a raw sample sheet into a form compatiable with bclconvert et al."""
+
+    # create base SampleSheet/ directory beside SampleSheet.csv
+    os.makedirs(os.path.join(os.path.dirname(out_path), "SampleSheet"), exist_ok=True)
+
     sample_sheet = SampleSheet(in_path, impute_lanes=impute_lanes)
     sample_sheet.write(out_path)
 


### PR DESCRIPTION
Essentially, bcl-convert expects to create the output directory in which it will write all files.

If this exists already, we get an error--the expected behaviour.

The method in BclConvertPaths to create the output directory causes a conflict as this was creating the out_dir before bclconvert resulting in an error. This method and call was removed.

bclconvert.stdout and bclconvert.stderr where shifted to SampleSheet/ as they can't be created prior to bclconvert creating the output directory. 

We can now delete bclconvert/ and rerun without issues, and we get the expected behaviour when the out_dir already exists.

Fixes #91