### PR TITLE
Add the missing summary files and plots in the html directory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -214,9 +214,15 @@
             buildInputs = [ R-with-GUSbase ];
           };
 
-          run_tag_count_plots = wrap-script {
+          tag_count_plots = wrap-script {
             name = "gbs_prism_tag_count_plots ";
             src = ./src/tag_count_plots.R;
+            buildInputs = [ pkgs.R ];
+          };
+
+          barcode_yield_plots = wrap-script {
+            name = "gbs_prism_barcode_yield_plots";
+            src = ./src/barcode_yields_plots.R;
             buildInputs = [ pkgs.R ];
           };
 
@@ -250,7 +256,8 @@
               paths = [
                 run_kgd
                 run_GUSbase
-                run_tag_count_plots
+                tag_count_plots
+                barcode_yield_plots
                 multiqc
               ] ++ (with flakePkgs; [
                 bbmap

--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,7 @@
               flakePkgs.gquery-api
               flakePkgs.geno-import
               psij-python
+              wand
             ];
 
           gbs-prism-api = with pkgs;
@@ -175,12 +176,7 @@
               propagatedBuildInputs = pipeline-packages;
             };
 
-          run_kgd = pkgs.stdenv.mkDerivation {
-            name = "gbs_prism_kgd";
-
-            src = ./src/run_kgd.R;
-
-            buildInputs = [ flakePkgs.kgd-src ];
+          wrap-script = attrs: pkgs.stdenv.mkDerivation ({
             nativeBuildInputs = [ pkgs.makeWrapper ];
 
             dontUnpack = true;
@@ -189,10 +185,19 @@
             installPhase = ''
               mkdir -p $out/bin
               runHook preInstall
-              cp $src $out/bin/run_kgd.R
-              chmod 755 $out/bin/run_kgd.R
+              # strip the path and digest, see https://nix.dev/manual/nix/2.25/store/store-path
+              basename=$(basename $src | sed -e "s/^[a-z0-9]*-//")
+              cp $src $out/bin/$basename
+              chmod 755 $out/bin/$basename
+              ls -l $out/bin
               runHook postInstall
             '';
+          } // attrs);
+
+          run_kgd = wrap-script {
+            name = "gbs_prism_kgd";
+            src = ./src/run_kgd.R;
+            buildInputs = [ flakePkgs.kgd-src ];
 
             postFixup = ''
               wrapProgram $out/bin/run_kgd.R --set KGD_SRC "${flakePkgs.kgd-src}"
@@ -203,25 +208,17 @@
             packages = [ flakePkgs.GUSbase ];
           };
 
-          run_GUSbase =
-            pkgs.stdenv.mkDerivation {
-              name = "gbs_prism_GUSbase";
+          run_GUSbase = wrap-script {
+            name = "gbs_prism_GUSbase";
+            src = ./src/run_GUSbase.R;
+            buildInputs = [ R-with-GUSbase ];
+          };
 
-              src = ./src/run_GUSbase.R;
-
-              buildInputs = [ R-with-GUSbase ];
-
-              dontUnpack = true;
-              dontBuild = true;
-
-              installPhase = ''
-                mkdir -p $out/bin
-                runHook preInstall
-                cp $src $out/bin/run_GUSbase.R
-                chmod 755 $out/bin/run_GUSbase.R
-                runHook postInstall
-              '';
-            };
+          run_tag_count_plots = wrap-script {
+            name = "gbs_prism_tag_count_plots ";
+            src = ./src/tag_count_plots.R;
+            buildInputs = [ pkgs.R ];
+          };
 
           redun-with-gbs-prism = inputs.redun.lib.${system}.default {
             propagatedBuildInputs = [ gbs-prism-api ];
@@ -253,6 +250,7 @@
               paths = [
                 run_kgd
                 run_GUSbase
+                run_tag_count_plots
                 multiqc
               ] ++ (with flakePkgs; [
                 bbmap
@@ -343,3 +341,4 @@
         }
       );
 }
+

--- a/pipeline.py
+++ b/pipeline.py
@@ -59,13 +59,13 @@ def main(
 
     stage2 = run_stage2(run=run, spec=stage1.spec, gbs_paths=stage1.gbs_paths)
 
-    stage3 = run_stage3(run_root=stage1.gbs_paths.run_root, stage2=stage2)
+    stage3 = run_stage3(stage2=stage2, out_dir=stage1.gbs_paths.report_dir)
 
     reports = create_reports(
         run=run,
         postprocessing_root=path["postprocessing_root"],
-        gbs_paths=stage1.gbs_paths,
         stage2=stage2,
+        out_dir=stage1.gbs_paths.report_dir,
     )
 
     warehoused = warehouse(

--- a/pipeline.py
+++ b/pipeline.py
@@ -9,8 +9,10 @@ from agr.redun.cluster_executor import create_cluster_executor_config
 from agr.gbs_prism.redun import (
     run_stage1,
     run_stage2,
+    run_stage3,
     Stage1Output,
     Stage2Output,
+    Stage3Output,
     create_reports,
     warehouse,
 )
@@ -27,7 +29,7 @@ logging.basicConfig(
 #     logging.getLogger(noisy_module).setLevel(logging.WARN)
 
 
-MainResults = tuple[Stage1Output, Stage2Output, list[File], str]
+MainResults = tuple[Stage1Output, Stage2Output, Stage3Output, list[File], str]
 
 
 @task()
@@ -57,6 +59,8 @@ def main(
 
     stage2 = run_stage2(run=run, spec=stage1.spec, gbs_paths=stage1.gbs_paths)
 
+    stage3 = run_stage3(run_root=stage1.gbs_paths.run_root, stage2=stage2)
+
     reports = create_reports(
         run=run,
         postprocessing_root=path["postprocessing_root"],
@@ -69,7 +73,7 @@ def main(
     )
 
     # the return value forces evaluation of the lazy expressions, otherwise nothing happens
-    return catch_all((stage1, stage2, reports, warehoused), Exception, recover)
+    return catch_all((stage1, stage2, stage3, reports, warehoused), Exception, recover)
 
 
 def init():

--- a/src/agr/gbs_prism/paths.py
+++ b/src/agr/gbs_prism/paths.py
@@ -84,6 +84,10 @@ class GbsPaths:
         return self._run_root
 
     @property
+    def report_dir(self) -> str:
+        return os.path.join(self._run_root, "html")
+
+    @property
     def target_spec_path(self) -> str:
         return os.path.join(self._run_root, "target-spec.json")
 

--- a/src/agr/gbs_prism/redun/__init__.py
+++ b/src/agr/gbs_prism/redun/__init__.py
@@ -2,14 +2,17 @@
 
 from .stage1 import run_stage1, Stage1Output
 from .stage2 import run_stage2, Stage2Output
+from .stage3 import run_stage3, Stage3Output
 from .reports import create_reports
 from .warehouse import warehouse
 
 __all__ = [
     "run_stage1",
     "run_stage2",
+    "run_stage3",
     "Stage1Output",
     "Stage2Output",
+    "Stage3Output",
     "create_reports",
     "warehouse",
 ]

--- a/src/agr/gbs_prism/redun/reports.py
+++ b/src/agr/gbs_prism/redun/reports.py
@@ -12,7 +12,6 @@ from agr.util.report import (
     Link,
     render_report,
 )
-from agr.gbs_prism.paths import GbsPaths
 from agr.gbs_prism.make_cohort_pages import make_cohort_pages
 from agr.redun.tasks.kgd import KgdOutput
 
@@ -159,11 +158,10 @@ def _create_cohorts_report(
 def create_reports(
     run: str,
     postprocessing_root: str,
-    gbs_paths: GbsPaths,
     stage2: Stage2Output,
+    out_dir: str,
 ) -> list[File]:
     _ = stage2  # depending on existence rather than value
-    out_dir = os.path.join(gbs_paths.run_root, "html")
     os.makedirs(out_dir, exist_ok=True)
     all_reports = []
 

--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -30,10 +30,6 @@ from agr.redun.tasks import (
     # Tassel:
     get_fastq_to_tag_count,
     get_tag_count,
-    get_tags_reads_summary,
-    get_tags_reads_list,
-    get_tags_reads_plots,
-    get_tags_reads_cv,
     merge_taxa_tag_count,
     tag_count_to_tag_pair,
     tag_pair_to_tbt,
@@ -130,10 +126,6 @@ class CohortOutput:
     tag_count: File
     collated_tag_count: File
     imported_gbs_read_tag_counts_marker: File
-    tags_reads_summary: File
-    tags_reads_list: File
-    tags_reads_cv: File
-    tags_reads_plots: dict[str, File]
     merged_all_count: File
     tag_pair: File
     tags_by_taxa: File
@@ -203,15 +195,6 @@ def run_cohort(spec: CohortSpec) -> CohortOutput:
         run=spec.run, collated_tag_count=collated_tag_count
     )
 
-    tags_reads_summary = get_tags_reads_summary(
-        spec.paths.cohort_dir(spec.cohort.name), tag_count
-    )
-    tags_reads_list = get_tags_reads_list(
-        spec.paths.cohort_dir(spec.cohort.name), tag_count
-    )
-    tags_reads_cv = get_tags_reads_cv(tags_reads_summary)
-    tags_read_plots = get_tags_reads_plots(tags_reads_list)
-
     merged_all_count = merge_taxa_tag_count(
         cohort_blind_dir, fastq_to_tag_count.tag_counts
     )
@@ -268,10 +251,6 @@ def run_cohort(spec: CohortSpec) -> CohortOutput:
         tag_count=tag_count,
         collated_tag_count=collated_tag_count,
         imported_gbs_read_tag_counts_marker=imported_gbs_read_tag_counts_marker,
-        tags_reads_summary=tags_reads_summary,
-        tags_reads_list=tags_reads_list,
-        tags_reads_cv=tags_reads_cv,
-        tags_reads_plots=tags_read_plots,
         merged_all_count=merged_all_count,
         tag_pair=tag_pair,
         tags_by_taxa=tags_by_taxa,

--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -124,6 +124,7 @@ class CohortOutput:
     keyfile_for_tassel: File
     keyfile_for_gbsx: File
     tag_count: File
+    fastq_to_tag_count_stdout: File
     collated_tag_count: File
     imported_gbs_read_tag_counts_marker: File
     merged_all_count: File
@@ -249,6 +250,7 @@ def run_cohort(spec: CohortSpec) -> CohortOutput:
         keyfile_for_tassel=keyfile_for_tassel,
         keyfile_for_gbsx=keyfile_for_gbsx,
         tag_count=tag_count,
+        fastq_to_tag_count_stdout=fastq_to_tag_count.stdout,
         collated_tag_count=collated_tag_count,
         imported_gbs_read_tag_counts_marker=imported_gbs_read_tag_counts_marker,
         merged_all_count=merged_all_count,

--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -31,6 +31,8 @@ from agr.redun.tasks import (
     get_fastq_to_tag_count,
     get_tag_count,
     get_tags_reads_summary,
+    get_tags_reads_list,
+    get_tags_reads_plots,
     get_tags_reads_cv,
     merge_taxa_tag_count,
     tag_count_to_tag_pair,
@@ -129,7 +131,9 @@ class CohortOutput:
     collated_tag_count: File
     imported_gbs_read_tag_counts_marker: File
     tags_reads_summary: File
+    tags_reads_list: File
     tags_reads_cv: File
+    tags_reads_plots: dict[str, File]
     merged_all_count: File
     tag_pair: File
     tags_by_taxa: File
@@ -202,7 +206,11 @@ def run_cohort(spec: CohortSpec) -> CohortOutput:
     tags_reads_summary = get_tags_reads_summary(
         spec.paths.cohort_dir(spec.cohort.name), tag_count
     )
+    tags_reads_list = get_tags_reads_list(
+        spec.paths.cohort_dir(spec.cohort.name), tag_count
+    )
     tags_reads_cv = get_tags_reads_cv(tags_reads_summary)
+    tags_read_plots = get_tags_reads_plots(tags_reads_list)
 
     merged_all_count = merge_taxa_tag_count(
         cohort_blind_dir, fastq_to_tag_count.tag_counts
@@ -261,7 +269,9 @@ def run_cohort(spec: CohortSpec) -> CohortOutput:
         collated_tag_count=collated_tag_count,
         imported_gbs_read_tag_counts_marker=imported_gbs_read_tag_counts_marker,
         tags_reads_summary=tags_reads_summary,
+        tags_reads_list=tags_reads_list,
         tags_reads_cv=tags_reads_cv,
+        tags_reads_plots=tags_read_plots,
         merged_all_count=merged_all_count,
         tag_pair=tag_pair,
         tags_by_taxa=tags_by_taxa,

--- a/src/agr/gbs_prism/redun/stage3.py
+++ b/src/agr/gbs_prism/redun/stage3.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from redun import task, File
+
+redun_namespace = "agr.gbs_prism"
+
+from agr.redun.tasks import (
+    get_tags_reads_summary,
+    get_tags_reads_list,
+    get_tags_reads_plots,
+    get_tags_reads_cv,
+)
+
+from .stage2 import Stage2Output
+
+
+@dataclass
+class Stage3Output:
+    tags_reads_summary: File
+    tags_reads_list: File
+    tags_reads_cv: File
+    tags_reads_plots: dict[str, File]
+
+
+@task()
+def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
+    tag_counts = [cohort.tag_count_unblind for cohort in stage2.cohorts.values()]
+
+    tags_reads_summary = get_tags_reads_summary(run_root, tag_counts)
+    tags_reads_list = get_tags_reads_list(run_root, tag_counts)
+    tags_reads_cv = get_tags_reads_cv(tags_reads_summary)
+    tags_read_plots = get_tags_reads_plots(tags_reads_list)
+
+    # the return value forces evaluation of the lazy expressions, otherwise nothing happens
+    return Stage3Output(
+        tags_reads_summary=tags_reads_summary,
+        tags_reads_list=tags_reads_list,
+        tags_reads_cv=tags_reads_cv,
+        tags_reads_plots=tags_read_plots,
+    )

--- a/src/agr/gbs_prism/redun/stage3.py
+++ b/src/agr/gbs_prism/redun/stage3.py
@@ -10,6 +10,7 @@ from agr.redun.tasks import (
     get_tags_reads_plots,
     get_tags_reads_cv,
     collate_mapping_stats,
+    collate_barcode_yields,
 )
 
 from .stage2 import Stage2Output
@@ -22,6 +23,7 @@ class Stage3Output:
     tags_reads_cv: File
     tags_reads_plots: dict[str, File]
     bam_stats_summary: File
+    barcode_yield_summary: File
 
 
 @task()
@@ -49,6 +51,16 @@ def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
         bam_stats_files, out_path=os.path.join(run_root, "stats_summary.txt")
     )
 
+    fastq_to_tag_count_stdouts = {
+        cohort_name: cohort.fastq_to_tag_count_stdout
+        for cohort_name, cohort in stage2.cohorts.items()
+    }
+
+    barcode_yield_summary = collate_barcode_yields(
+        fastq_to_tag_count_stdouts,
+        out_path=os.path.join(run_root, "barcode_yield_summary.txt"),
+    )
+
     # the return value forces evaluation of the lazy expressions, otherwise nothing happens
     return Stage3Output(
         tags_reads_summary=tags_reads_summary,
@@ -56,4 +68,5 @@ def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
         tags_reads_cv=tags_reads_cv,
         tags_reads_plots=tags_read_plots,
         bam_stats_summary=bam_stats_summary,
+        barcode_yield_summary=barcode_yield_summary,
     )

--- a/src/agr/gbs_prism/redun/stage3.py
+++ b/src/agr/gbs_prism/redun/stage3.py
@@ -23,7 +23,10 @@ class Stage3Output:
 
 @task()
 def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
-    tag_counts = [cohort.tag_count_unblind for cohort in stage2.cohorts.values()]
+    tag_counts = sorted(
+        [cohort.tag_count_unblind for cohort in stage2.cohorts.values()],
+        key=lambda file: file.path,
+    )
 
     tags_reads_summary = get_tags_reads_summary(run_root, tag_counts)
     tags_reads_list = get_tags_reads_list(run_root, tag_counts)

--- a/src/agr/gbs_prism/redun/stage3.py
+++ b/src/agr/gbs_prism/redun/stage3.py
@@ -1,5 +1,6 @@
 import os.path
 from dataclasses import dataclass
+from agr.redun.tasks.barcode_yields import plot_barcode_yields
 from redun import task, File
 
 redun_namespace = "agr.gbs_prism"
@@ -24,6 +25,7 @@ class Stage3Output:
     tags_reads_plots: dict[str, File]
     bam_stats_summary: File
     barcode_yield_summary: File
+    barcode_yields_plot: File
 
 
 @task()
@@ -61,6 +63,8 @@ def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
         out_path=os.path.join(run_root, "barcode_yield_summary.txt"),
     )
 
+    barcode_yields_plot = plot_barcode_yields(barcode_yield_summary)
+
     # the return value forces evaluation of the lazy expressions, otherwise nothing happens
     return Stage3Output(
         tags_reads_summary=tags_reads_summary,
@@ -69,4 +73,5 @@ def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
         tags_reads_plots=tags_read_plots,
         bam_stats_summary=bam_stats_summary,
         barcode_yield_summary=barcode_yield_summary,
+        barcode_yields_plot=barcode_yields_plot,
     )

--- a/src/agr/gbs_prism/redun/stage3.py
+++ b/src/agr/gbs_prism/redun/stage3.py
@@ -29,14 +29,14 @@ class Stage3Output:
 
 
 @task()
-def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
+def run_stage3(stage2: Stage2Output, out_dir: str) -> Stage3Output:
     tag_counts = sorted(
         [cohort.tag_count_unblind for cohort in stage2.cohorts.values()],
         key=lambda file: file.path,
     )
 
-    tags_reads_summary = get_tags_reads_summary(run_root, tag_counts)
-    tags_reads_list = get_tags_reads_list(run_root, tag_counts)
+    tags_reads_summary = get_tags_reads_summary(out_dir, tag_counts)
+    tags_reads_list = get_tags_reads_list(out_dir, tag_counts)
     tags_reads_cv = get_tags_reads_cv(tags_reads_summary)
     tags_read_plots = get_tags_reads_plots(tags_reads_list)
 
@@ -50,7 +50,7 @@ def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
     )
 
     bam_stats_summary = collate_mapping_stats(
-        bam_stats_files, out_path=os.path.join(run_root, "stats_summary.txt")
+        bam_stats_files, out_path=os.path.join(out_dir, "stats_summary.txt")
     )
 
     fastq_to_tag_count_stdouts = {
@@ -60,7 +60,7 @@ def run_stage3(run_root: str, stage2: Stage2Output) -> Stage3Output:
 
     barcode_yield_summary = collate_barcode_yields(
         fastq_to_tag_count_stdouts,
-        out_path=os.path.join(run_root, "barcode_yield_summary.txt"),
+        out_path=os.path.join(out_dir, "barcode_yield_summary.txt"),
     )
 
     barcode_yields_plot = plot_barcode_yields(barcode_yield_summary)

--- a/src/agr/redun/__init__.py
+++ b/src/agr/redun/__init__.py
@@ -2,7 +2,7 @@
 
 from . import cluster_executor
 from .cluster_executor import ClusterExecutorConfig
-from .util import concat, one_forall, one_foreach, all_forall, lazy_map
+from .util import concat, one_forall, one_foreach, all_forall, lazy_map, existing_file
 
 __all__ = [
     "cluster_executor",
@@ -12,4 +12,5 @@ __all__ = [
     "one_foreach",
     "all_forall",
     "lazy_map",
+    "existing_file",
 ]

--- a/src/agr/redun/tasks/__init__.py
+++ b/src/agr/redun/tasks/__init__.py
@@ -12,7 +12,7 @@ from .keyfiles import get_gbs_keyfiles, get_keyfile_for_tassel, get_keyfile_for_
 from .kmer_analysis import kmer_analysis_one, kmer_analysis_all
 from .multiqc import multiqc
 from .sample_sheet import cook_sample_sheet
-from .samtools import bam_stats_one, bam_stats_all
+from .samtools import bam_stats_one, bam_stats_all, collate_mapping_stats
 from .kgd import kgd
 from .gupdate import (
     import_gbs_read_tag_counts,
@@ -40,6 +40,7 @@ from .unblind import unblind_one, unblind_all, get_unblind_script
 __all__ = [
     "bam_stats_one",
     "bam_stats_all",
+    "collate_mapping_stats",
     "bcl_convert",
     "bwa_aln_one",
     "bwa_aln_all",

--- a/src/agr/redun/tasks/__init__.py
+++ b/src/agr/redun/tasks/__init__.py
@@ -3,6 +3,7 @@
 from .bcl_convert import bcl_convert
 from .bwa import bwa_aln_one, bwa_aln_all, bwa_samse_one, bwa_samse_all
 from .collate_tags_reads import collate_tags_reads, collate_tags_reads_kgdstats
+from .collate_barcode_yields import collate_barcode_yields
 from .cutadapt import cutadapt_one, cutadapt_all
 from .dedupe import dedupe_one, dedupe_all
 from .fake_bcl_convert import fake_bcl_convert, real_or_fake_bcl_convert
@@ -41,6 +42,7 @@ __all__ = [
     "bam_stats_one",
     "bam_stats_all",
     "collate_mapping_stats",
+    "collate_barcode_yields",
     "bcl_convert",
     "bwa_aln_one",
     "bwa_aln_all",

--- a/src/agr/redun/tasks/__init__.py
+++ b/src/agr/redun/tasks/__init__.py
@@ -24,7 +24,9 @@ from .tassel3 import (
     get_fastq_to_tag_count,
     get_tag_count,
     get_tags_reads_summary,
+    get_tags_reads_list,
     get_tags_reads_cv,
+    get_tags_reads_plots,
     merge_taxa_tag_count,
     tag_count_to_tag_pair,
     tag_pair_to_tbt,
@@ -69,7 +71,9 @@ __all__ = [
     "get_fastq_to_tag_count",
     "get_tag_count",
     "get_tags_reads_summary",
+    "get_tags_reads_list",
     "get_tags_reads_cv",
+    "get_tags_reads_plots",
     "merge_taxa_tag_count",
     "tag_count_to_tag_pair",
     "tag_pair_to_tbt",
@@ -78,5 +82,5 @@ __all__ = [
     # Unblind:
     "unblind_one",
     "unblind_all",
-    "get_unblind_script"
+    "get_unblind_script",
 ]

--- a/src/agr/redun/tasks/__init__.py
+++ b/src/agr/redun/tasks/__init__.py
@@ -1,9 +1,9 @@
 # re-exports for agr.redun.tasks
 
+from .barcode_yields import collate_barcode_yields
 from .bcl_convert import bcl_convert
 from .bwa import bwa_aln_one, bwa_aln_all, bwa_samse_one, bwa_samse_all
 from .collate_tags_reads import collate_tags_reads, collate_tags_reads_kgdstats
-from .collate_barcode_yields import collate_barcode_yields
 from .cutadapt import cutadapt_one, cutadapt_all
 from .dedupe import dedupe_one, dedupe_all
 from .fake_bcl_convert import fake_bcl_convert, real_or_fake_bcl_convert

--- a/src/agr/redun/tasks/__init__.py
+++ b/src/agr/redun/tasks/__init__.py
@@ -20,13 +20,15 @@ from .gupdate import (
     import_gbs_kgd_stats,
 )
 from .gusbase import gusbase
-from .tassel3 import (
-    get_fastq_to_tag_count,
-    get_tag_count,
+from .tags import (
     get_tags_reads_summary,
     get_tags_reads_list,
     get_tags_reads_cv,
     get_tags_reads_plots,
+)
+from .tassel3 import (
+    get_fastq_to_tag_count,
+    get_tag_count,
     merge_taxa_tag_count,
     tag_count_to_tag_pair,
     tag_pair_to_tbt,

--- a/src/agr/redun/tasks/barcode_yields.py
+++ b/src/agr/redun/tasks/barcode_yields.py
@@ -1,5 +1,9 @@
+import os.path
 import re
 from redun import task, File
+
+from agr.redun import existing_file
+from agr.util.subprocess import run_catching_stderr
 
 
 @task()
@@ -51,3 +55,18 @@ def collate_barcode_yields(uneak_stdout_files: dict[str, File], out_path: str) -
             print("\t".join(out_rec), file=out_f)
 
     return File(out_path)
+
+
+@task()
+def plot_barcode_yields(barcode_yield_summary: File) -> File:
+    data_dir = os.path.dirname(barcode_yield_summary.path)
+    _ = run_catching_stderr(
+        [
+            "barcode_yields_plots.R",
+            f"datafolder={data_dir}",
+        ]
+    )
+
+    out_path = os.path.join(data_dir, "barcode_yields.jpg")
+
+    return existing_file(out_path)

--- a/src/agr/redun/tasks/collate_barcode_yields.py
+++ b/src/agr/redun/tasks/collate_barcode_yields.py
@@ -1,0 +1,53 @@
+import re
+from redun import task, File
+
+
+@task()
+def collate_barcode_yields(uneak_stdout_files: dict[str, File], out_path: str) -> File:
+    stats_dict = {}
+
+    #  example = """
+    # Total number of reads in lane=243469299
+    # Total number of good barcoded reads=199171115
+    # """
+
+    for cohort_name, uneak_stdout_file in uneak_stdout_files.items():
+        sample_ref = cohort_name
+
+        yield_stats = [0.0, 0.0]  # will contain total reads, total good barcoded
+
+        with open(uneak_stdout_file.path, "r") as f:
+            for record in f:
+                hit = re.search(
+                    r"^Total number of reads in lane=(\d+)$", record.strip()
+                )
+                if hit is not None:
+                    yield_stats[1] += float(hit.groups()[0])
+                hit = re.search(
+                    r"^Total number of good barcoded reads=(\d+)$", record.strip()
+                )
+                if hit is not None:
+                    yield_stats[0] += float(hit.groups()[0])
+
+        stats_dict[sample_ref] = yield_stats
+
+    with open(out_path, "w") as out_f:
+        print("\t".join(("sample_ref", "good_pct", "good_std")), file=out_f)
+        for sample_ref in sorted(stats_dict.keys()):
+            out_rec = [sample_ref, "0", "0"]
+
+            n = stats_dict[sample_ref][1]
+            if n > 0:
+                p = stats_dict[sample_ref][0] / stats_dict[sample_ref][1]
+            else:
+                p = 0
+
+            q = 1 - p
+            stddev = 0.0
+            if n > 0:
+                stddev = (p * q / n) ** 0.5
+            out_rec[1] = str(p * 100.0)
+            out_rec[2] = str(stddev * 100.0)
+            print("\t".join(out_rec), file=out_f)
+
+    return File(out_path)

--- a/src/agr/redun/tasks/samtools.py
+++ b/src/agr/redun/tasks/samtools.py
@@ -1,8 +1,11 @@
-import logging
+import os
+import re
 from redun import task, File
 
 from agr.util.subprocess import run_catching_stderr
 from agr.redun import one_forall
+
+import logging
 
 logger = logging.getLogger(__name__)
 
@@ -20,5 +23,58 @@ def bam_stats_one(bam_file: File) -> File:
 
 @task()
 def bam_stats_all(bam_files: list[File]) -> list[File]:
-    """bwa samse for multiple files with a single reference genome."""
+    """run samtools flagstat for multiple files."""
     return one_forall(bam_stats_one, bam_files)
+
+
+@task()
+def collate_mapping_stats(stats_files: list[File], out_path: str) -> File:
+    # adapted, fixed, and simplified from legacy seq_prisms collate_mapping_stats.py
+
+    stats_dict = {}
+
+    for stats_file in sorted(
+        stats_files,
+        key=lambda file: file.path,
+    ):
+        sample_ref = re.sub(
+            # fixed this regex to actually match our filenames 🤦
+            r"(\.txt)?(\.gz)?\.fastq\.[sm]\d+\.trimmed\.fastq\.bwa",
+            "",
+            os.path.basename(stats_file.path),
+        )
+        sample_ref = re.sub(r"\.B10\.stats", "", sample_ref)
+
+        map_stats = [0.0, 0.0, 0.0]  # will contain count, total, percent
+
+        with open(stats_file.path, "r") as f:
+            for record in f:
+                tokens = re.split(r"\s+", record.strip())
+                if len(tokens) >= 5:
+                    if (tokens[3], tokens[4]) == ("in", "total"):
+                        map_stats[1] = float(tokens[0])
+                    elif tokens[3] == "mapped":
+                        map_stats[0] = float(tokens[0])
+                        if map_stats[1] > 0:
+                            map_stats[2] = map_stats[0] / map_stats[1]
+                        else:
+                            map_stats[2] = 0.0
+                        break
+
+        stats_dict[sample_ref] = map_stats
+
+    with open(out_path, "w") as out_f:
+        print("\t".join(("sample_ref", "map_pct", "map_std")), file=out_f)
+        for sample_ref in stats_dict:
+            out_rec = [sample_ref, "0", "0"]
+            (p, n) = (stats_dict[sample_ref][2], stats_dict[sample_ref][1])
+
+            q = 1 - p
+            stddev = 0.0
+            if n > 0:
+                stddev = (p * q / n) ** 0.5
+            out_rec[1] = str(p * 100.0)
+            out_rec[2] = str(stddev * 100.0)
+            print("\t".join(out_rec), file=out_f)
+
+    return File(out_path)

--- a/src/agr/redun/tasks/tags.py
+++ b/src/agr/redun/tasks/tags.py
@@ -1,0 +1,80 @@
+import logging
+import os.path
+from agr.util.image import append_images_horizontally
+from redun import task, File
+
+from agr.redun import existing_file
+from agr.util.subprocess import run_catching_stderr
+
+logger = logging.getLogger(__name__)
+
+
+@task()
+def get_tags_reads_summary(out_dir: str, tagCountCsvs: list[File]) -> File:
+    out_path = os.path.join(out_dir, "tags_reads_summary.txt")
+    _ = run_catching_stderr(
+        ["summarise_read_and_tag_counts", "-o", out_path]
+        + [tagCountCsv.path for tagCountCsv in tagCountCsvs],
+        check=True,
+    )
+    return File(out_path)
+
+
+@task()
+def get_tags_reads_list(out_dir: str, tagCountCsvs: list[File]) -> File:
+    out_path = os.path.join(out_dir, "tags_reads_list.txt")
+    _ = run_catching_stderr(
+        [
+            "summarise_read_and_tag_counts",
+            "-t",
+            "unsummarised",
+            "-o",
+            out_path,
+        ]
+        + [tagCountCsv.path for tagCountCsv in tagCountCsvs],
+        check=True,
+    )
+    return File(out_path)
+
+
+@task()
+def get_tags_reads_cv(tags_reads_summary: File) -> File:
+    out_path = os.path.join(
+        os.path.dirname(tags_reads_summary.path), "tags_reads_cv.txt"
+    )
+    with open(out_path, "w") as out_f:
+        _ = run_catching_stderr(
+            ["cut", "-f", "1,4,9", tags_reads_summary.path], stdout=out_f, check=True
+        )
+    return File(out_path)
+
+
+@task()
+def get_tags_reads_plots(tags_reads_list: File) -> dict[str, File]:
+    out_dir = os.path.dirname(tags_reads_list.path)
+    _ = run_catching_stderr(
+        [
+            "tag_count_plots.R",
+            f"infile={tags_reads_list.path}",
+            f"outfolder={out_dir}",
+        ]
+    )
+
+    # append the individual plots as was done in legacy
+    READ_STATS = "read_stats.jpg"
+    TAG_STATS = "tag_stats.jpg"
+    TAG_READ_STATS = "tag_read_stats.jpg"
+
+    def out_file(basename: str) -> File:
+        return existing_file(os.path.join(out_dir, basename))
+
+    results = {basename: out_file(basename) for basename in [READ_STATS, TAG_STATS]}
+
+    tag_read_stats_path = os.path.join(out_dir, TAG_READ_STATS)
+
+    append_images_horizontally(
+        [results[TAG_STATS].path, results[READ_STATS].path],
+        out_path=tag_read_stats_path,
+    )
+
+    return results | {TAG_READ_STATS: existing_file(tag_read_stats_path)}

--- a/src/agr/redun/tasks/tassel3.py
+++ b/src/agr/redun/tasks/tassel3.py
@@ -2,11 +2,9 @@ import logging
 import os.path
 import re
 from dataclasses import dataclass
-from agr.util.image import append_images_horizontally
 from redun import task, File
 from typing import Any
 
-from agr.redun import existing_file
 from agr.util.path import symlink
 from agr.util.subprocess import run_catching_stderr
 from agr.seq.enzyme_sub import enzyme_sub_for_uneak
@@ -278,75 +276,6 @@ def get_tag_count(fastqToTagCountStdout: File) -> File:
                 ["get_reads_tags_per_sample"], stdin=in_f, stdout=out_f, check=True
             )
     return File(out_path)
-
-
-@task()
-def get_tags_reads_summary(out_dir: str, tagCountCsv: File) -> File:
-    out_path = os.path.join(out_dir, "tags_reads_summary.txt")
-    _ = run_catching_stderr(
-        ["summarise_read_and_tag_counts", "-o", out_path, tagCountCsv.path], check=True
-    )
-    return File(out_path)
-
-
-@task()
-def get_tags_reads_list(out_dir: str, tagCountCsv: File) -> File:
-    out_path = os.path.join(out_dir, "tags_reads_list.txt")
-    _ = run_catching_stderr(
-        [
-            "summarise_read_and_tag_counts",
-            "-t",
-            "unsummarised",
-            "-o",
-            out_path,
-            tagCountCsv.path,
-        ],
-        check=True,
-    )
-    return File(out_path)
-
-
-@task()
-def get_tags_reads_cv(tags_reads_summary: File) -> File:
-    out_path = os.path.join(
-        os.path.dirname(tags_reads_summary.path), "tags_reads_cv.txt"
-    )
-    with open(out_path, "w") as out_f:
-        _ = run_catching_stderr(
-            ["cut", "-f", "1,4,9", tags_reads_summary.path], stdout=out_f, check=True
-        )
-    return File(out_path)
-
-
-@task()
-def get_tags_reads_plots(tags_reads_list: File) -> dict[str, File]:
-    out_dir = os.path.dirname(tags_reads_list.path)
-    _ = run_catching_stderr(
-        [
-            "tag_count_plots.R",
-            f"infile={tags_reads_list.path}",
-            f"outfolder={out_dir}",
-        ]
-    )
-
-    # append the individual plots as was done in legacy
-    READ_STATS = "read_stats.jpg"
-    TAG_STATS = "tag_stats.jpg"
-    TAG_READ_STATS = "tag_read_stats.jpg"
-
-    def out_file(basename: str) -> File:
-        return existing_file(os.path.join(out_dir, basename))
-
-    results = {basename: out_file(basename) for basename in [READ_STATS, TAG_STATS]}
-
-    tag_read_stats_path = os.path.join(out_dir, TAG_READ_STATS)
-
-    append_images_horizontally(
-        [results[TAG_STATS].path, results[READ_STATS].path],
-        out_path=tag_read_stats_path,
-    )
-
-    return results | {TAG_READ_STATS: existing_file(tag_read_stats_path)}
 
 
 @task()

--- a/src/agr/redun/tasks/tassel3.py
+++ b/src/agr/redun/tasks/tassel3.py
@@ -2,9 +2,11 @@ import logging
 import os.path
 import re
 from dataclasses import dataclass
+from agr.util.image import append_images_horizontally
 from redun import task, File
 from typing import Any
 
+from agr.redun import existing_file
 from agr.util.path import symlink
 from agr.util.subprocess import run_catching_stderr
 from agr.seq.enzyme_sub import enzyme_sub_for_uneak
@@ -288,6 +290,23 @@ def get_tags_reads_summary(out_dir: str, tagCountCsv: File) -> File:
 
 
 @task()
+def get_tags_reads_list(out_dir: str, tagCountCsv: File) -> File:
+    out_path = os.path.join(out_dir, "tags_reads_list.txt")
+    _ = run_catching_stderr(
+        [
+            "summarise_read_and_tag_counts",
+            "-t",
+            "unsummarised",
+            "-o",
+            out_path,
+            tagCountCsv.path,
+        ],
+        check=True,
+    )
+    return File(out_path)
+
+
+@task()
 def get_tags_reads_cv(tags_reads_summary: File) -> File:
     out_path = os.path.join(
         os.path.dirname(tags_reads_summary.path), "tags_reads_cv.txt"
@@ -297,6 +316,37 @@ def get_tags_reads_cv(tags_reads_summary: File) -> File:
             ["cut", "-f", "1,4,9", tags_reads_summary.path], stdout=out_f, check=True
         )
     return File(out_path)
+
+
+@task()
+def get_tags_reads_plots(tags_reads_list: File) -> dict[str, File]:
+    out_dir = os.path.dirname(tags_reads_list.path)
+    _ = run_catching_stderr(
+        [
+            "tag_count_plots.R",
+            f"infile={tags_reads_list.path}",
+            f"outfolder={out_dir}",
+        ]
+    )
+
+    # append the individual plots as was done in legacy
+    READ_STATS = "read_stats.jpg"
+    TAG_STATS = "tag_stats.jpg"
+    TAG_READ_STATS = "tag_read_stats.jpg"
+
+    def out_file(basename: str) -> File:
+        return existing_file(os.path.join(out_dir, basename))
+
+    results = {basename: out_file(basename) for basename in [READ_STATS, TAG_STATS]}
+
+    tag_read_stats_path = os.path.join(out_dir, TAG_READ_STATS)
+
+    append_images_horizontally(
+        [results[TAG_STATS].path, results[READ_STATS].path],
+        out_path=tag_read_stats_path,
+    )
+
+    return results | {TAG_READ_STATS: existing_file(tag_read_stats_path)}
 
 
 @task()

--- a/src/agr/redun/util.py
+++ b/src/agr/redun/util.py
@@ -1,8 +1,14 @@
 # helpers for redun
-from redun import task, Task
+import os.path
+from redun import task, Task, File
 from typing import Any, Callable
 
 redun_namespace = "agr.util"
+
+
+class PathError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
 
 
 @task()
@@ -35,3 +41,11 @@ def all_forall(task: Task, items: list[Any], **kw_task_args) -> list[Any]:
 def lazy_map(x: Any, f: Callable[[Any], Any]) -> Any:
     """Map f over the expression `x`."""
     return f(x)
+
+
+def existing_file(path: str) -> File:
+    """Return path as file, failing if it doesn't exist."""
+    if os.path.exists(path):
+        return File(path)
+    else:
+        raise PathError(f"no such file: {path}")

--- a/src/agr/util/image.py
+++ b/src/agr/util/image.py
@@ -1,0 +1,26 @@
+from wand.image import Image
+
+
+def append_images_horizontally(images: list[str], out_path: str):
+    final_width = 0
+    max_height = 0
+
+    # Get total width and max height
+    img_objects = []
+    for img_path in images:
+        img = Image(filename=img_path)
+        img_objects.append(img)
+        final_width += img.width
+        max_height = max(max_height, img.height)
+
+    # Create a new image with the combined dimensions
+    final_image = Image(width=final_width, height=max_height)
+
+    # Compose images
+    x_offset = 0
+    for img in img_objects:
+        final_image.composite(img, left=x_offset, top=0)
+        x_offset += img.width
+
+    # Save the appended image
+    final_image.save(filename=out_path)

--- a/src/barcode_yields_plots.R
+++ b/src/barcode_yields_plots.R
@@ -1,0 +1,68 @@
+#!/usr/bin/env Rscript --vanilla
+#
+#-------------------------------------------------------------------------
+# plot the % reads mappng
+#-------------------------------------------------------------------------
+
+
+get_command_args <- function() {
+   args=(commandArgs(TRUE))
+   if(length(args)!=1 ){
+      #quit with error message if wrong number of args supplied
+      print('Usage example : Rscript --vanilla  barcode_yields_plots.r datafolder=/dataset/gseq_processing/scratch/gbs/200310_D00390_0538_BCE5FNANXX/html')
+      print('args received were : ')
+      for (e in args) {
+         print(e)
+      }
+      q()
+   }else{
+      print("Using...")
+      # seperate and parse command-line args
+      for (e in args) {
+         print(e)
+         ta <- strsplit(e,"=",fixed=TRUE)
+         switch(ta[[1]][1],
+            "datafolder" = datafolder <- ta[[1]][2]
+         )
+      }
+   }
+   return(datafolder)
+}
+
+
+
+data_folder<-get_command_args()
+
+setwd(data_folder)
+barcode_yields = read.table("barcode_yield_summary.txt", header=TRUE, sep="\t")
+#sample_ref      good_pct        good_std
+#SQ2886  80.2707271056   0.00258529641497
+#SQ2887  74.7603990784   0.00262088745101
+#SQ1243  87.2703283787   0.00225369772438
+
+barcode_yields <- barcode_yields[order(barcode_yields$good_pct),]
+
+
+jpeg("barcode_yields.jpg", height=nrow(barcode_yields) *  80, width=900)
+
+
+# ref
+# refs for this way of doing error bars
+# http://environmentalcomputing.net/single-continuous-vs-categorical-variables/
+# https://stackoverflow.com/questions/13032777/scatter-plot-with-error-bars
+
+margins=par("mar")
+margins[2] = 9 * margins[2]
+par(mar=margins)
+
+#sets the bottom, left, top and right margins respectively of the plot region in number of lines of text.
+
+mapping.plot <- barplot(barcode_yields$good_pct, names.arg = barcode_yields$sample_ref, horiz=TRUE, las=2,
+                      xlab="Good barcoded reads %", ylab = "Library",xlim=c(0,100), cex.names = 0.8)
+
+lower <- barcode_yields$good_pct - barcode_yields$good_std
+upper <- barcode_yields$good_pct + barcode_yields$good_std
+
+#arrows(mapping.plot, lower, mapping.plot, upper, angle=90, code=3)
+arrows(lower, mapping.plot, upper, mapping.plot, angle=90, code=3, length=.1)
+dev.off()

--- a/src/tag_count_plots.R
+++ b/src/tag_count_plots.R
@@ -1,0 +1,98 @@
+#!/usr/bin/env Rscript --vanilla
+#
+#
+#-------------------------------------------------------------------------
+# plot the tag and read mean and stddev
+#-------------------------------------------------------------------------
+
+
+get_command_args <- function() {
+   args=(commandArgs(TRUE))
+   if(length(args)!=2 ){
+      #quit with error message if wrong number of args supplied
+      print('Usage example : Rscript --vanilla  tag_count_plots.r infile=/dataset/gseq_processing/scratch/gbs/200407_D00390_0541_BCE3EWANXX/html/tags_reads_summary.txt  outfolder=/dataset/gseq_processing/scratch/gbs/200407_D00390_0541_BCE3EWANXX/html' )
+      print('args received were : ')
+      for (e in args) {
+         print(e)
+      }
+      q()
+   }else{
+      print("Using...")
+      # seperate and parse command-line args
+      for (e in args) {
+         print(e)
+         ta <- strsplit(e,"=",fixed=TRUE)
+         switch(ta[[1]][1],
+            "outfolder" = outfolder <<- ta[[1]][2],
+            "infile" = infile <<- ta[[1]][2]
+         )
+      }
+   }
+}
+
+# example
+#flowcell_sq_cohort      mean_tag_count  std_tag_count   min_tag_count   max_tag_count   mean_read_count std_read_count  min_read_count  max_read_count
+#SQ1257.all.PstI.PstI_CE3EWANXX_SQ1257   253258.066845   29503.126706    41196   333481  700922.302139   175178.466915   50064   1315737
+#SQ1258.all.PstI.PstI_CE3EWANXX_SQ1258   243487.630319   19029.8927137   40472   324748  696395.071809   115029.175347   49835   1314941
+#SQ1259.all.PstI.PstI_CE3EWANXX_SQ1259   242148.553191   57613.3610063   39672   368608  689894.276596   281653.607972   54937   1606162
+
+get_command_args()
+setwd(outfolder)
+read_tag_stats = read.table(infile, header=TRUE, sep="\t")
+read_tag_stats <- read_tag_stats[order(read_tag_stats$cohort),]
+
+###### tags #######
+
+jpeg("tag_stats.jpg", height=800, width=800)
+
+# ref
+# refs for this way of doing error bars
+# http://environmentalcomputing.net/single-continuous-vs-categorical-variables/
+# https://stackoverflow.com/questions/13032777/scatter-plot-with-error-bars
+
+margins=par("mar")
+margins[2] = 6 * margins[2]
+par(mar=margins)
+
+#sets the bottom, left, top and right margins respectively of the plot region in number of lines of text.
+
+#tags.plot <- barplot(read_tag_stats$mean_tag_count, names.arg = read_tag_stats$flowcell_sq_cohort, horiz=TRUE, las=2,
+#                      xlab="Mean tag count", ylab = "Cohort",cex.names = 0.8, xlim=c(min(read_tag_stats$mean_tag_count - 1.01*read_tag_stats$std_tag_count) , max(read_tag_stats$mean_tag_count + 1.01*read_tag_stats$std_tag_count)))
+
+tags.plot <- boxplot(tags~cohort, data=read_tag_stats, main="Tag counts", xlab="Tag count", ylab = "Cohort",cex.names = 0.8, horizontal=TRUE,las=1)
+#lower <- read_tag_stats$mean_tag_count - read_tag_stats$std_tag_count
+#upper <- read_tag_stats$mean_tag_count + read_tag_stats$std_tag_count
+
+#arrows(mapping.plot, lower, mapping.plot, upper, angle=90, code=3)
+#arrows(lower, tags.plot, upper, tags.plot, angle=90, code=3, length=.1)
+dev.off()
+
+###### reads #######
+
+jpeg("read_stats.jpg", height=800, width=800)
+
+# ref
+# refs for this way of doing error bars
+# http://environmentalcomputing.net/single-continuous-vs-categorical-variables/
+# https://stackoverflow.com/questions/13032777/scatter-plot-with-error-bars
+
+margins=par("mar")
+margins[2] = 6 * margins[2]
+par(mar=margins)
+
+#sets the bottom, left, top and right margins respectively of the plot region in number of lines of text.
+
+#tags.plot <- barplot(read_tag_stats$mean_read_count, names.arg = read_tag_stats$flowcell_sq_cohort, horiz=TRUE, las=2,
+#                      xlab="Mean read count", ylab = "Cohort",cex.names = 0.8, xlim=c(min(read_tag_stats$mean_read_count - 1.01*read_tag_stats$std_read_count) , max(read_tag_stats$mean_read_count + 1.01*read_tag_stats$std_read_count)))
+tags.plot <- boxplot(reads~cohort, data=read_tag_stats, main="Read counts", xlab="Read count", ylab = "Cohort",cex.names = 0.8, horizontal=TRUE,las=1)
+
+#lower <- read_tag_stats$mean_read_count - read_tag_stats$std_read_count
+#upper <- read_tag_stats$mean_read_count + read_tag_stats$std_read_count
+
+#arrows(mapping.plot, lower, mapping.plot, upper, angle=90, code=3)
+#arrows(lower, tags.plot, upper, tags.plot, angle=90, code=3, length=.1)
+
+
+
+dev.off()
+


### PR DESCRIPTION
These are not yet referenced from the peacock plot, that's next to be done.

Introduced Stage 3, which consolidates output across the cohorts.  A couple of tag read summary files which were previously being generated per cohort have now been fixed to collate across cohorts as per legacy gbs_prism.

Various Python and R scripts extracted from legacy gbs_prism and seq_prisms, ported to Python 3, fixed and tidied up.

Fixes #58