### PR TITLE
Remove existing directory before running bcl-convert

### DIFF
--- a/src/agr/redun/tasks/bcl_convert.py
+++ b/src/agr/redun/tasks/bcl_convert.py
@@ -1,5 +1,6 @@
 import logging
 import os.path
+import shutil
 from dataclasses import dataclass
 from redun import task, File
 from typing import Optional
@@ -107,6 +108,12 @@ def bcl_convert(
     expected_fastq: set[str],
 ) -> BclConvertOutput:
     paths = BclConvertPaths(out_dir)
+
+    # if redun thinks we need to run bcl-convert, we'd better run it,
+    # which means removing any previous run, since bcl-convert cannot
+    # cope with existing directory
+    if os.path.isdir(out_dir):
+        shutil.rmtree(out_dir)
 
     fastq_files = run_job_n(
         _bcl_convert_job_spec(


### PR DESCRIPTION
This seems necessary to cope with reruns of redun.

Not yet tested.  Will do so before merging.

If you want to subsume this into your sample sheet update changes and test altogether, please go ahead, and we can close this PR.