### PR TITLE
Enable production run from development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ When working like this, `gbs_prism` itself is made available to Python by virtue
 
 When you change directory to anywhere other than the main repo or its children, the direnv environment is unloaded.
 
+### GQuery environments for development
+
+By default when working in the Nix devshell the GQuery dev environment is active.  In general, this is all that is needed and all that is appropriate.
+
+However, in case of needing access to other GQuery environments, they may be loaded up and confirmed as follows.
+
+```
+source $GQUERY_TEST_ENV
+gquery -t info
+```
+
+The other environments are available via `GQUERY_DEV_ENV` and `GQUERY_PROD_ENV`.
+
 ## Notes
 
 1. historical_unblind has been omitted, seems not to be required

--- a/context/eri-prod.json
+++ b/context/eri-prod.json
@@ -1,6 +1,6 @@
 {
   "path": {
-    "seq_root": "/agr/persist/projects/2024_illumina_sequencing_f/active",
+    "seq_root": "/agr/persist/projects/2025_illumina_sequencing_f/active",
     "postprocessing_root": "/agr/persist/projects/2024_illumina_sequencing_g/postprocessing",
     "keyfiles_dir": "/agr/persist/projects/2024_illumina_sequencing_g/key-files",
     "fastq_link_farm": "/agr/persist/projects/2024_illumina_sequencing_g/fastq-link-farm",

--- a/context/eri-prod.json
+++ b/context/eri-prod.json
@@ -1,0 +1,10 @@
+{
+  "path": {
+    "seq_root": "/agr/persist/projects/2024_illumina_sequencing_f/active",
+    "postprocessing_root": "/agr/persist/projects/2024_illumina_sequencing_g/postprocessing",
+    "keyfiles_dir": "/agr/persist/projects/2024_illumina_sequencing_g/key-files",
+    "fastq_link_farm": "/agr/persist/projects/2024_illumina_sequencing_g/fastq-link-farm",
+    "gbs_backup_dir": "/agr/scratch/projects/2024_illumina_sequencing_g/backups",
+    "geno_import_dir": "/agr/scratch/projects/2024_illumina_sequencing_g/geno-import"
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -320,15 +320,27 @@
                   flakePkgs.seffs
                 ];
 
-              shellHook = ''
-                export REDUN_CONFIG=$(pwd)/.redun
-                # enable use of gbs_prism from current directory during development
-                export PYTHONPATH=$(pwd)/src:$PYTHONPATH
-                ${gquery-export-env "dev"}
-                export GQUERY_ROOT=$HOME/gquery-logs
-                export GENO_ROOT=$HOME/geno-logs
-                export GBS_PRISM_EXECUTOR_CONFIG=$(pwd)/config/eri-executor.jsonnet
-              '';
+              shellHook =
+                let
+                  gquery-env = env: pkgs.writeTextFile {
+                    name = "gquery-${env}-env";
+                    text = gquery-export-env env;
+                  };
+                in
+                ''
+                  export REDUN_CONFIG=$(pwd)/.redun
+                  # enable use of gbs_prism from current directory during development
+                  export PYTHONPATH=$(pwd)/src:$PYTHONPATH
+                  ${gquery-export-env "dev"}
+                  export GQUERY_ROOT=$HOME/gquery-logs
+                  export GENO_ROOT=$HOME/geno-logs
+                  export GBS_PRISM_EXECUTOR_CONFIG=$(pwd)/config/eri-executor.jsonnet
+
+                  # for switching GQuery environments
+                  export GQUERY_DEV_ENV=${gquery-env "dev"}
+                  export GQUERY_TEST_ENV=${gquery-env "test"}
+                  export GQUERY_PROD_ENV=${gquery-env "prod"}
+                '';
             };
           };
 


### PR DESCRIPTION
Ultimately we will have a deployment that doesn't require a local clone of the git repo.  But for now, this enables switching between environments as described in the README.

Also, first attempt at `eri-prod.json` context, we may want to tweak that.

Fastq link farm needs more thought, but we can always move the links later.  Same comment for keyfiles dir.

I am concerned about the backup and geno import dirs, as these would seem to break if two people are running at the same time.  But it has always been like that.

These directories need to be created by hand before the production run (if that's what we decide to go with):
```
    "keyfiles_dir": "/agr/persist/projects/2024_illumina_sequencing_g/key-files",
    "fastq_link_farm": "/agr/persist/projects/2024_illumina_sequencing_g/fastq-link-farm",
    "gbs_backup_dir": "/agr/scratch/projects/2024_illumina_sequencing_g/backups",
    "geno_import_dir": "/agr/scratch/projects/2024_illumina_sequencing_g/geno-import"
```
