### PR TITLE
Await run complete

### DIFF
--- a/src/agr/gbs_prism/redun/stage1.py
+++ b/src/agr/gbs_prism/redun/stage1.py
@@ -85,9 +85,11 @@ class Stage1Output:
 
 
 @task()
-def get_sample_sheet(sample_sheet_path: str) -> File:
-    """Get the sample sheet path."""
-    return File(sample_sheet_path)
+def await_run_complete(sequencer_run: SequencerRun) -> File:
+    """Await run complete and return the sample sheet as a file, so we retrigger if it changes."""
+    sequencer_run.await_complete()
+
+    return File(sequencer_run.sample_sheet_path)
 
 
 @task()
@@ -108,8 +110,10 @@ def run_stage1(
     )
     seq_paths = SeqPaths(illumina_platform_run_root)
 
+    raw_sample_sheet = await_run_complete(sequencer_run)
+
     seq = cook_sample_sheet(
-        in_file=get_sample_sheet(sequencer_run.sample_sheet_path),
+        in_file=raw_sample_sheet,
         out_path=seq_paths.sample_sheet_path,
     )
 

--- a/src/agr/seq/sequencer_run.py
+++ b/src/agr/seq/sequencer_run.py
@@ -54,25 +54,25 @@ class SequencerRun:
         overall_timeout: Optional[timedelta] = None,
     ):
         self.validate()
-        rta_complete_path = os.path.join(self._dir, "RTAComplete.txt")
+        copy_complete_path = os.path.join(self._dir, "CopyComplete.txt")
         deadline = (
             datetime.now() + overall_timeout if overall_timeout is not None else None
         )
-        while not os.path.exists(rta_complete_path) and (
+        while not os.path.exists(copy_complete_path) and (
             deadline is None or deadline < datetime.now()
         ):
             print(
                 "%s does not exist, sleeping for %s"
-                % (rta_complete_path, poll_interval)
+                % (copy_complete_path, poll_interval)
             )
             logger.info(
                 "%s does not exist, sleeping for %s"
-                % (rta_complete_path, poll_interval)
+                % (copy_complete_path, poll_interval)
             )
             time.sleep(poll_interval.total_seconds())
-        if not os.path.exists(rta_complete_path):
-            raise SequencerRunError("timeout waiting for %s" % rta_complete_path)
-        logger.info("%s found, run is complete" % rta_complete_path)
+        if not os.path.exists(copy_complete_path):
+            raise SequencerRunError("timeout waiting for %s" % copy_complete_path)
+        logger.info("%s found, run is complete" % copy_complete_path)
 
     # TODO move this to a more appropriate class, perhaps
     def exists_in_database(self):


### PR DESCRIPTION
Using CopyComplete.txt rather than RTAComplete.txt as previously, which we recently discovered is incorrect.

I found nothing in the redun docs about task timeout, nor in the source code, so this should happily wait forever (not tested).

Fixes #82