### PR TITLE
Import stats

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -6,6 +6,7 @@ from redun.scheduler import catch_all
 
 from agr.util.path import expand
 from agr.redun.cluster_executor import create_cluster_executor_config
+from agr.redun.util import await_results
 from agr.gbs_prism.redun import (
     run_stage1,
     run_stage2,
@@ -39,16 +40,6 @@ def recover(results: MainResults) -> MainResults:
     we loiter until all tasks are done or failed.
     """
     return results
-
-
-@task()
-def _all_stages_complete(
-    stage1: Stage1Output, stage2: Stage2Output, stage3: Stage3Output
-) -> bool:
-    _ = stage1
-    _ = stage2
-    _ = stage3
-    return True
 
 
 @task()
@@ -86,7 +77,7 @@ def main(
 
     # must warehouse after everything else is done (except reports)
     warehoused = warehouse(
-        ready_to_warehouse=_all_stages_complete(stage1, stage2, stage3),
+        ready=await_results([stage1, stage2, stage3]),
         geno_import_dir=path["geno_import_dir"],
         log_dir=stage1.gbs_paths.run_root,
     )

--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -357,7 +357,9 @@ def run_stage2(
         out_path=os.path.join(gbs_paths.run_root, "ImportedCollatedTagCounts.tsv"),
     )
 
-    # as does this, which we think we must run after the other 😬
+    # as does this, which we must run after the other, according to this comment buried deep inside gquery 😬
+    #
+    # These two partial updates should always be run together, in the order import_gbs_read_tag_counts, then import_gbs_kgd_stats
     imported_gbs_kgd_stats = import_gbs_kgd_stats(
         ready=await_results(imported_collated_tag_counts),
         run=run,

--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -348,24 +348,24 @@ def run_stage2(
         cohort_outputs[name] = run_cohort(target, gbs_keyfiles[cohort.libname])
 
     # this import step need to be once for all cohorts
-    imported_gbs_kgd_stats = import_gbs_kgd_stats(
-        run,
-        [
-            lazy_map(cohort_output, _cohort_gbs_kgd_stats_import)
-            for cohort_output in cohort_outputs.values()
-        ],
-        out_path=os.path.join(gbs_paths.run_root, "gbs_kgd_stats_import.tsv"),
-    )
-
-    # as does this, which we run after the other
     imported_collated_tag_counts = import_gbs_read_tag_counts(
-        ready=await_results(imported_gbs_kgd_stats),
         run=run,
         collated_tag_counts=[
             lazy_map(cohort_output, _collated_tag_count)
             for cohort_output in cohort_outputs.values()
         ],
         out_path=os.path.join(gbs_paths.run_root, "ImportedCollatedTagCounts.tsv"),
+    )
+
+    # as does this, which we think we must run after the other 😬
+    imported_gbs_kgd_stats = import_gbs_kgd_stats(
+        ready=await_results(imported_collated_tag_counts),
+        run=run,
+        cohort_imports=[
+            lazy_map(cohort_output, _cohort_gbs_kgd_stats_import)
+            for cohort_output in cohort_outputs.values()
+        ],
+        out_path=os.path.join(gbs_paths.run_root, "gbs_kgd_stats_import.tsv"),
     )
 
     # and this import step is done for each cohort separately

--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -1,6 +1,7 @@
 import os.path
 from dataclasses import dataclass
 from agr.redun.tasks.gupdate import import_gbs_kgd_stats, import_gbs_kgd_cohort_stats
+from agr.redun.util import await_results
 from redun import task, File
 from typing import Optional
 
@@ -356,8 +357,9 @@ def run_stage2(
         out_path=os.path.join(gbs_paths.run_root, "gbs_kgd_stats_import.tsv"),
     )
 
-    # as does this
+    # as does this, which we run after the other
     imported_collated_tag_counts = import_gbs_read_tag_counts(
+        ready=await_results(imported_gbs_kgd_stats),
         run=run,
         collated_tag_counts=[
             lazy_map(cohort_output, _collated_tag_count)

--- a/src/agr/gbs_prism/redun/warehouse.py
+++ b/src/agr/gbs_prism/redun/warehouse.py
@@ -39,8 +39,8 @@ def import_genophyle_gbs_import_file(
 
 
 @task()
-def warehouse(ready_to_warehouse: bool, geno_import_dir: str, log_dir: str) -> str:
-    _ = ready_to_warehouse
+def warehouse(ready: bool, geno_import_dir: str, log_dir: str) -> str:
+    _ = ready
 
     os.makedirs(geno_import_dir, exist_ok=True)
 

--- a/src/agr/redun/tasks/gupdate.py
+++ b/src/agr/redun/tasks/gupdate.py
@@ -10,10 +10,8 @@ from agr.util import map_columns
 
 @task()
 def import_gbs_read_tag_counts(
-    ready: bool, run: str, collated_tag_counts: list[File], out_path: str
+    run: str, collated_tag_counts: list[File], out_path: str
 ) -> File:
-    _ = ready
-
     # concatenate all import files
     with open(out_path, "w") as out_f:
         for collated_tag_count in collated_tag_counts:
@@ -56,13 +54,14 @@ def create_cohort_gbs_kgd_stats_import(
 
 @task()
 def import_gbs_kgd_stats(
-    run: str, cohort_imports: list[Optional[File]], out_path: str
+    ready: bool, run: str, cohort_imports: list[Optional[File]], out_path: str
 ) -> File:
     """Import all KGD stats import files in one go, since importing individual files
     seems to result in database deadlock.
 
     Any cohorts for which KGD failed result in None in place of the import file, and we simply omit these.
     """
+    _ = ready
 
     # concatenate all import files
     with open(out_path, "w") as out_f:

--- a/src/agr/redun/tasks/gupdate.py
+++ b/src/agr/redun/tasks/gupdate.py
@@ -10,8 +10,10 @@ from agr.util import map_columns
 
 @task()
 def import_gbs_read_tag_counts(
-    run: str, collated_tag_counts: list[File], out_path: str
+    ready: bool, run: str, collated_tag_counts: list[File], out_path: str
 ) -> File:
+    _ = ready
+
     # concatenate all import files
     with open(out_path, "w") as out_f:
         for collated_tag_count in collated_tag_counts:

--- a/src/agr/redun/util.py
+++ b/src/agr/redun/util.py
@@ -43,6 +43,19 @@ def lazy_map(x: Any, f: Callable[[Any], Any]) -> Any:
     return f(x)
 
 
+@task()
+def await_results(results: Any) -> bool:
+    """
+    Simply use the results to trigger readiness to run a subsequent task.
+    This avoids for example having to pass in a file to a task just to trigger it.
+    Instead pass in the result of `await_files` to a parameter `ready` of the task in question,
+    which should assign it to `_` to avoid unused parameter warning.
+    (The name is purely convention; consistency provides clarity on what is happening.)
+    """
+    _ = results
+    return True
+
+
 def existing_file(path: str) -> File:
     """Return path as file, failing if it doesn't exist."""
     if os.path.exists(path):


### PR DESCRIPTION
The run which will confirm this is fixed is still in progress, but hopefully fixes the missing callrate and sampdepth stats.

Made `await_results` a utility, as we've used it in a couple of places now.
