### PR TITLE
Optional files for kgd

### DIFF
--- a/src/agr/redun/cluster_executor.py
+++ b/src/agr/redun/cluster_executor.py
@@ -127,7 +127,7 @@ class JobNSpec(CommonJobSpec):
     """
 
     # each value is either a result path or a filtered glob
-    expected_paths: ExpectedPaths = ExpectedPaths()
+    expected_paths: ExpectedPaths = field(default_factory=ExpectedPaths)
     expected_globs: dict[str, FilteredGlob] = field(default_factory=dict)
 
 

--- a/src/agr/redun/cluster_executor.py
+++ b/src/agr/redun/cluster_executor.py
@@ -112,6 +112,12 @@ class FilteredGlob:
 
 
 @dataclass(kw_only=True)
+class ExpectedPaths:
+    required: dict[str, str] = field(default_factory=dict)
+    optional: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(kw_only=True)
 class JobNSpec(CommonJobSpec):
     """
     For jobs which produce multiple files with paths matching the glob, exluding any matched by the regex.
@@ -121,7 +127,7 @@ class JobNSpec(CommonJobSpec):
     """
 
     # each value is either a result path or a filtered glob
-    expected_paths: dict[str, str] = field(default_factory=dict)
+    expected_paths: ExpectedPaths = ExpectedPaths()
     expected_globs: dict[str, FilteredGlob] = field(default_factory=dict)
 
 
@@ -344,18 +350,24 @@ class ResultFiles:
 def _result_files(
     job: Job,
     spec: CommonJobSpec,
-    expected_paths: dict[str, str],
+    expected_paths: ExpectedPaths,
     expected_globs: dict[str, FilteredGlob],
 ) -> ResultFiles:
     """Return result files for expected paths, or those matching filtered glob."""
-    for k, path in expected_paths.items():
+    # required items must all exist
+    for k, path in expected_paths.required.items():
         if not os.path.exists(path):
             raise ClusterExecutorError(
                 f"{job_description(job, spec, annotation=f'failed to create {k}={path}', multiline=True)}"
             )
+    found_paths = expected_paths.required.copy()
+    # optional paths are returned if they are found to exist
+    for k, path in expected_paths.optional.items():
+        if os.path.exists(path):
+            found_paths[k] = path
 
     return ResultFiles(
-        expected_files={k: File(path) for (k, path) in expected_paths.items()},
+        expected_files={k: File(path) for (k, path) in found_paths.items()},
         globbed_files={
             k: [
                 File(path)
@@ -375,6 +387,14 @@ def _run_job_n(
     """
     Run a job on the defined cluster, which is expected to produce files matching `result_glob`
     """
+
+    # check no duplicates between required and optional expected paths
+    duplicate_expected_keys = (
+        spec.expected_paths.required.keys() & spec.expected_paths.optional.keys()
+    )
+    assert (
+        len(duplicate_expected_keys) == 0
+    ), f"duplicate expected keys: {', '.join(duplicate_expected_keys)}"
 
     job_spec, executor_name = _create_job_spec(
         spec=spec,

--- a/src/agr/redun/tasks/fastqc.py
+++ b/src/agr/redun/tasks/fastqc.py
@@ -3,7 +3,7 @@ import os.path
 from dataclasses import dataclass
 from redun import task, File
 
-from agr.redun.cluster_executor import run_job_n, JobNSpec, ResultFiles
+from agr.redun.cluster_executor import run_job_n, JobNSpec, ExpectedPaths, ResultFiles
 from agr.redun import one_forall
 
 logger = logging.getLogger(__name__)
@@ -48,7 +48,9 @@ def _fastqc_job_spec(in_path: str, out_dir: str, num_threads: int = 8) -> JobNSp
         stdout_path=log_path,
         stderr_path=log_path,
         cwd=out_dir,
-        expected_paths={_HTML: html_out_path, _ZIP: zip_out_path},
+        expected_paths=ExpectedPaths(
+            required={_HTML: html_out_path, _ZIP: zip_out_path}
+        ),
     )
 
 

--- a/src/agr/redun/tasks/kgd.py
+++ b/src/agr/redun/tasks/kgd.py
@@ -193,8 +193,11 @@ def kgd(
         return KgdOutput(
             ok=True,
             text_files={
-                basename: result.expected_files[basename]
-                for basename in KGD_OUTPUT_TEXT_FILES_REQUIRED
+                basename: path
+                for basename in (
+                    KGD_OUTPUT_TEXT_FILES_REQUIRED + KGD_OUTPUT_TEXT_FILES_OPTIONAL
+                )
+                if (path := result.expected_files.get(basename)) is not None
             },
             binary_files={
                 basename: result.expected_files[basename]

--- a/src/agr/redun/tasks/kgd.py
+++ b/src/agr/redun/tasks/kgd.py
@@ -6,10 +6,11 @@ from typing import Optional
 
 from agr.redun.cluster_executor import (
     run_job_n_returning_failure,
-    ClusterExecutorJobFailure,
     JobNSpec,
+    ExpectedPaths,
     ResultFiles,
 )
+
 
 logger = logging.getLogger(__name__)
 
@@ -108,16 +109,18 @@ def _kgd_job_spec(
         stdout_path=out_path,
         stderr_path=err_path,
         cwd=out_dir,
-        expected_paths={
-            basename: os.path.join(out_dir, basename)
-            for basename in KGD_OUTPUT_TEXT_FILES
-            + KGD_OUTPUT_BINARY_FILES
-            + KGD_OUTPUT_PLOTS
-        }
-        | {
-            KGD_STDOUT: out_path,
-            KGD_STDERR: err_path,
-        },
+        expected_paths=ExpectedPaths(
+            required={
+                basename: os.path.join(out_dir, basename)
+                for basename in KGD_OUTPUT_TEXT_FILES
+                + KGD_OUTPUT_BINARY_FILES
+                + KGD_OUTPUT_PLOTS
+            }
+            | {
+                KGD_STDOUT: out_path,
+                KGD_STDERR: err_path,
+            }
+        ),
     )
 
 

--- a/src/agr/redun/tasks/kgd.py
+++ b/src/agr/redun/tasks/kgd.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 KGD_STDOUT = "KGD.stdout"
 KGD_STDERR = "KGD.stderr"
 
-KGD_OUTPUT_PLOTS = [
+KGD_OUTPUT_PLOTS_REQUIRED = [
     "AlleleFreq.png",
     "CallRate.png",
     "Co-call-HWdgm.05.png",
@@ -57,7 +57,7 @@ KGD_OUTPUT_PLOTS = [
     "X2star-QQ.png",
 ]
 
-KGD_OUTPUT_TEXT_FILES = [
+KGD_OUTPUT_TEXT_FILES_REQUIRED = [
     "GHW05.csv",
     "GHW05-Inbreeding.csv",
     "GHW05-long.csv",
@@ -66,15 +66,18 @@ KGD_OUTPUT_TEXT_FILES = [
     "GHW05-PC.csv",
     "GHW05.vcf",
     "HeatmapOrderHWdgm.05.csv",
-    # "HighRelatedness.csv",
-    # "HighRelatedness.split.csv",
     "SampleStats.csv",
     "SampleStatsRawCombined.csv",
     "SampleStatsRaw.csv",
     "seqID.csv",
 ]
 
-KGD_OUTPUT_BINARY_FILES = [
+KGD_OUTPUT_TEXT_FILES_OPTIONAL = [
+    "HighRelatedness.csv",
+    "HighRelatedness.split.csv",
+]
+
+KGD_OUTPUT_BINARY_FILES_REQUIRED = [
     "GHW05.RData",
     "GUSbase.RData",
 ]
@@ -112,14 +115,18 @@ def _kgd_job_spec(
         expected_paths=ExpectedPaths(
             required={
                 basename: os.path.join(out_dir, basename)
-                for basename in KGD_OUTPUT_TEXT_FILES
-                + KGD_OUTPUT_BINARY_FILES
-                + KGD_OUTPUT_PLOTS
+                for basename in KGD_OUTPUT_TEXT_FILES_REQUIRED
+                + KGD_OUTPUT_BINARY_FILES_REQUIRED
+                + KGD_OUTPUT_PLOTS_REQUIRED
             }
             | {
                 KGD_STDOUT: out_path,
                 KGD_STDERR: err_path,
-            }
+            },
+            optional={
+                basename: os.path.join(out_dir, basename)
+                for basename in KGD_OUTPUT_TEXT_FILES_OPTIONAL
+            },
         ),
     )
 
@@ -187,15 +194,15 @@ def kgd(
             ok=True,
             text_files={
                 basename: result.expected_files[basename]
-                for basename in KGD_OUTPUT_TEXT_FILES
+                for basename in KGD_OUTPUT_TEXT_FILES_REQUIRED
             },
             binary_files={
                 basename: result.expected_files[basename]
-                for basename in KGD_OUTPUT_BINARY_FILES
+                for basename in KGD_OUTPUT_BINARY_FILES_REQUIRED
             },
             plot_files={
                 basename: result.expected_files[basename]
-                for basename in KGD_OUTPUT_PLOTS
+                for basename in KGD_OUTPUT_PLOTS_REQUIRED
             },
             kgd_stdout=result.expected_files[KGD_STDOUT],
             kgd_stderr=result.expected_files[KGD_STDERR],

--- a/src/agr/redun/tasks/tassel3.py
+++ b/src/agr/redun/tasks/tassel3.py
@@ -15,6 +15,7 @@ from agr.redun.cluster_executor import (
     run_job_n,
     Job1Spec,
     JobNSpec,
+    ExpectedPaths,
     FilteredGlob,
 )
 
@@ -94,7 +95,7 @@ class Tassel3:
         self,
         plugin: str,
         plugin_args: list[str],
-        expected_paths: dict[str, str] = {},
+        expected_paths: ExpectedPaths = ExpectedPaths(),
         expected_globs: dict[str, FilteredGlob] = {},
     ) -> JobNSpec:
         return JobNSpec(
@@ -177,11 +178,13 @@ class Tassel3:
                 "-s",
                 "900000000",
             ],
-            expected_paths={
-                FASTQ_TO_TAG_COUNT_STDOUT: os.path.join(
-                    self._work_dir, "%s.stdout" % FASTQ_TO_TAG_COUNT_PLUGIN
-                ),
-            },
+            expected_paths=ExpectedPaths(
+                required={
+                    FASTQ_TO_TAG_COUNT_STDOUT: os.path.join(
+                        self._work_dir, "%s.stdout" % FASTQ_TO_TAG_COUNT_PLUGIN
+                    ),
+                }
+            ),
             expected_globs={
                 FASTQ_TO_TAG_COUNT_COUNTS: FilteredGlob("%s/*" % self.tag_counts_dir),
             },


### PR DESCRIPTION
This splits up the expected files for `run_job_n` into required and optional, and so far the only use for optional is the KGD high related CSVs.

Fixes #115 

I have tested it a few times, but would like to see a final successful run before merging it.  But I won't have time to do that today.  If you're so inclined, please have a go with it, and if you're happy, go ahead and merge it.