### PR TITLE
Return correct keyfile paths for walkins keyfiles

### DIFF
--- a/src/agr/redun/tasks/keyfiles.py
+++ b/src/agr/redun/tasks/keyfiles.py
@@ -158,10 +158,19 @@ def get_gbs_keyfiles(
     )
     gbs_keyfiles.create()
 
-    return {
-        library: File(os.path.join(out_dir, "%s.generated.txt" % library))
-        for library in gbs_libraries
-    }
+    keyfile_paths = {}
+    for library in gbs_libraries:
+        if os.path.exists(os.path.join(out_dir, "%s.generated.txt" % library)):
+            keyfile_paths[library] = File(
+                os.path.join(out_dir, "%s.generated.txt" % library)
+            )
+        elif os.path.exists(os.path.join(out_dir, "%s.txt" % library)):
+            keyfile_paths[library] = File(os.path.join(out_dir, "%s.txt" % library))
+        else:
+            raise FileNotFoundError(
+                f"Keyfile for library {library} not found in {out_dir}."
+            )
+    return keyfile_paths
 
 
 @task()


### PR DESCRIPTION
Keyfiles for walkins are imported correctly and exported with qc ids for downstream processing. This is just a small fix to the path construction of the imported keyfiles when there are walkins keyfiles.