### PR TITLE
prepending cohort to TagCount.csv file names

### DIFF
--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -39,7 +39,11 @@ from agr.redun.tasks import (
 )
 from agr.redun.tasks.bwa import Bwa
 from agr.redun.tasks.fastq_sample import FastqSampleSpec
-from agr.redun.tasks.tassel3 import fastq_name_for_tassel3, hap_map_dir
+from agr.redun.tasks.tassel3 import (
+    fastq_name_for_tassel3,
+    hap_map_dir,
+    cohort_name_tag_counts,
+)
 from agr.redun.tasks.kgd import KgdOutput, kgd_dir
 from agr.redun.tasks.unblind import (
     get_unblind_script,
@@ -139,7 +143,7 @@ class CohortOutput:
     collated_kgd_stats: Optional[File]
     collated_kgd_stats_unblind: Optional[File]
     gusbase_comet: Optional[File]
-    tag_count_unblind: File
+    cohort_tag_counts: File
     hap_map_files_unblind: list[File]
     kgd_text_files_unblind: dict[str, File]
     kgd_stdout_unblind: Optional[File]
@@ -233,6 +237,9 @@ def run_cohort(spec: CohortSpec, gbs_keyfile: File) -> CohortOutput:
     tag_count_unblind = unblind_one(
         tag_count, unblind_script, spec.paths.cohort_dir(spec.cohort.name)
     )
+
+    cohort_tag_counts = cohort_name_tag_counts(tag_count_unblind, spec.cohort.name)
+
     hap_map_files_unblind = unblind_all(
         hap_map_files,
         unblind_script,
@@ -304,7 +311,7 @@ def run_cohort(spec: CohortSpec, gbs_keyfile: File) -> CohortOutput:
         collated_kgd_stats=collated_kgd_stats,
         collated_kgd_stats_unblind=collated_kgd_stats_unblind,
         gusbase_comet=gusbase_comet,
-        tag_count_unblind=tag_count_unblind,
+        cohort_tag_counts=cohort_tag_counts,
         hap_map_files_unblind=hap_map_files_unblind,
         kgd_text_files_unblind=kgd_text_files_unblind,
         kgd_stdout_unblind=kgd_stdout_unblind,

--- a/src/agr/gbs_prism/redun/stage3.py
+++ b/src/agr/gbs_prism/redun/stage3.py
@@ -33,7 +33,7 @@ def run_stage3(stage2: Stage2Output, out_dir: str) -> Stage3Output:
     os.makedirs(out_dir, exist_ok=True)
 
     tag_counts = sorted(
-        [cohort.tag_count_unblind for cohort in stage2.cohorts.values()],
+        [cohort.cohort_tag_counts for cohort in stage2.cohorts.values()],
         key=lambda file: file.path,
     )
 

--- a/src/agr/redun/tasks/tassel3.py
+++ b/src/agr/redun/tasks/tassel3.py
@@ -1,5 +1,5 @@
 import logging
-import os.path
+import os
 import re
 from dataclasses import dataclass
 from redun import task, File
@@ -275,6 +275,14 @@ def get_tag_count(fastqToTagCountStdout: File) -> File:
             _ = run_catching_stderr(
                 ["get_reads_tags_per_sample"], stdin=in_f, stdout=out_f, check=True
             )
+    return File(out_path)
+
+
+@task()
+def cohort_name_tag_counts(tag_count: File, cohort: str) -> File:
+    """Rename the tag count file to include the cohort name."""
+    out_path = os.path.join(os.path.dirname(tag_count.path), f"{cohort}.TagCount.csv")
+    os.rename(tag_count.path, out_path)
     return File(out_path)
 
 


### PR DESCRIPTION
As requested y Hayley to allow multiple TagCount.csv files to be open in excel at once.

Tested with run 358 on 21-05-2025.

Fixes #131