### PR TITLE
Slight bump to Tassel3Default job spec

### DIFF
--- a/config/eri-executor.jsonnet
+++ b/config/eri-executor.jsonnet
@@ -33,7 +33,7 @@ local Tassel3Default = ToolDefault {
   job_attributes+: {
     custom_attributes+: customised({
       'cpus-per-task': '1',
-      mem: '2G',
+      mem: '4G',
     }),
   },
 };


### PR DESCRIPTION
I saw a tassel3_TBTToMapInfo job killed, this seems to be what's required.