### PR TITLE
Postgres backend for  redun

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> run.gbs_keyfiles.create()
 ```
 
+## Postgres Backend
+
+All production runs now store their redun state in the `gbs_prism_redun` database on `molten`.  This means that users will see a common history of runs when using `redun console`.
+
+Authorisation for database access is by Kerberos ticket as for the other databases.  The host is `n-db-molten-[dtp]1`, database `gbs_prism_redun` and role `gbs_prism_redun`.
+
+In dev and test, the default is to continue with a local SQLite database, for ease of purging redun database state.  If desired, the Postgres backend may be selected by setting the environmemt variable `REDUN_CONFIG` to `$(pwd)/config/redun.dev` or `$(pwd)/config/redun.test`.
+
+When switching GQuery environments for development as described below, when switching to the `prod` environment, the `prod` Postgres backend will be activated (by automatically setting `REDUN_CONFIG`), and when switching to the other environments the local SQLite backend will be selected (by unsetting `REDUN_CONFIG`.)  See the content of e.g. `$GBS_PRISM_PROD_ENV` to understand how this works.
+
 ## Development
 
 All of the dependencies are deployed using Nix.  The best way to work on `gbs_prism` itself is in the Nix devshell using `direnv`.  When doing this, ensure you don't have any `gbs_prism` environment module loaded.
@@ -84,14 +94,14 @@ When you change directory to anywhere other than the main repo or its children, 
 
 By default when working in the Nix devshell the GQuery dev environment is active.  In general, this is all that is needed and all that is appropriate.
 
-However, in case of needing access to other GQuery environments, they may be loaded up and confirmed as follows.
+However, in case of needing access to other GQuery environments, they may be loaded up and confirmed as follows.  Note that since adding the Postgres database backends there is additional `gbs_prism` specific configuration to switch, so the environment variables have been changed from `GQUERY` prefixed ones to `GBS_PRISM` prefixed.
 
 ```
-source $GQUERY_TEST_ENV
+source $GBS_PRISM_TEST_ENV
 gquery -t info
 ```
 
-The other environments are available via `GQUERY_DEV_ENV` and `GQUERY_PROD_ENV`.
+The other environments are available via `GBS_PRISM_DEV_ENV` and `GBS_PRISM_PROD_ENV`.
 
 ## Notes
 

--- a/config/redun.dev/redun.ini
+++ b/config/redun.dev/redun.ini
@@ -1,0 +1,9 @@
+# redun configuration.
+
+[backend]
+# db_uri = sqlite:///redun.db
+db_uri = postgresql://n-db-molten-d1.dev.eri.agresearch.co.nz:5432/gbs_prism_redun
+
+[executors.default]
+type = local
+max_workers = 20

--- a/config/redun.prod/redun.ini
+++ b/config/redun.prod/redun.ini
@@ -1,0 +1,9 @@
+# redun configuration.
+
+[backend]
+# db_uri = sqlite:///redun.db
+db_uri = postgresql://n-db-molten-p1.eri.agresearch.co.nz:5432/gbs_prism_redun
+
+[executors.default]
+type = local
+max_workers = 20

--- a/config/redun.test/redun.ini
+++ b/config/redun.test/redun.ini
@@ -1,0 +1,9 @@
+# redun configuration.
+
+[backend]
+# db_uri = sqlite:///redun.db
+db_uri = postgresql://n-db-molten-t1.test.eri.agresearch.co.nz:5432/gbs_prism_redun
+
+[executors.default]
+type = local
+max_workers = 20

--- a/flake.nix
+++ b/flake.nix
@@ -260,6 +260,12 @@
                   export GQUERY_DEV_ENV=${gquery-env "dev"}
                   export GQUERY_TEST_ENV=${gquery-env "test"}
                   export GQUERY_PROD_ENV=${gquery-env "prod"}
+
+                  # for postgres database backend, will use the default config in .redun
+                  # unless this is defined:
+                  # export REDUN_CONFIG="$(pwd)/config/redun.dev"
+                  export REDUN_DB_USERNAME="gbs_prism_redun"
+                  export REDUN_DB_PASSWORD="unused because Kerberos"
                 '';
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -242,9 +242,15 @@
 
               shellHook =
                 let
-                  gquery-env = env: pkgs.writeTextFile {
-                    name = "gquery-${env}-env";
-                    text = gquery-export-env env;
+                  gbs-prism-env = env: pkgs.writeTextFile {
+                    name = "gbs-prism-${env}-env";
+                    text = (if env == "prod" then ''
+                      export REDUN_CONFIG="$(pwd)/config/redun.${env}"
+                    ''
+                    else ''
+                      unset REDUN_CONFIG
+                    '')
+                    + gquery-export-env env;
                   };
                 in
                 ''
@@ -256,10 +262,10 @@
                   export GENO_ROOT=$HOME/geno-logs
                   export GBS_PRISM_EXECUTOR_CONFIG=$(pwd)/config/eri-executor.jsonnet
 
-                  # for switching GQuery environments
-                  export GQUERY_DEV_ENV=${gquery-env "dev"}
-                  export GQUERY_TEST_ENV=${gquery-env "test"}
-                  export GQUERY_PROD_ENV=${gquery-env "prod"}
+                  # for switching GQuery and gbs_prism environments
+                  export GBS_PRISM_DEV_ENV=${gbs-prism-env "dev"}
+                  export GBS_PRISM_TEST_ENV=${gbs-prism-env "test"}
+                  export GBS_PRISM_PROD_ENV=${gbs-prism-env "prod"}
 
                   # for postgres database backend, will use the default config in .redun
                   # unless this is defined:


### PR DESCRIPTION
To enable this, three gbs_prism_redun databases were deployed on the molten postgres server in eRI, one each for dev, test, prod.  Authorization is as for gquery with Kerberos tickets, so kinit is required before running redun console.

Postgres backend config exists for all three environments, but we probably will only use it for prod.

Now that there is additional `gbs_prism` specific configuration to deal with when switching the development environment between dev, test, and prod, the environment variables have been changed from `GQUERY` prefixed ones to `GBS_PRISM` prefixed, as described in the README.

Fixes #143