### PR TITLE
KGD optional plots

### DIFF
--- a/src/agr/redun/cluster_executor.py
+++ b/src/agr/redun/cluster_executor.py
@@ -315,7 +315,12 @@ def _run_job_1(
     else:
         if not os.path.exists(spec.expected_path):
             raise ClusterExecutorError(
-                f"{job_description(job, spec, annotation=f'failed to create {spec.expected_path}', multiline=True)}"
+                job_description(
+                    job,
+                    spec,
+                    annotation=f"failed to create {spec.expected_path}",
+                    multiline=True,
+                )
             )
 
         return File(spec.expected_path)
@@ -355,11 +360,22 @@ def _result_files(
 ) -> ResultFiles:
     """Return result files for expected paths, or those matching filtered glob."""
     # required items must all exist
+    missing_required_paths = {}
     for k, path in expected_paths.required.items():
         if not os.path.exists(path):
-            raise ClusterExecutorError(
-                f"{job_description(job, spec, annotation=f'failed to create {k}={path}', multiline=True)}"
+            missing_required_paths[k] = path
+    if missing_required_paths:
+        raise ClusterExecutorError(
+            job_description(
+                job,
+                spec,
+                annotation="failed to create %s"
+                % ", ".join(
+                    [f"{k}={path}" for (k, path) in missing_required_paths.items()]
+                ),
+                multiline=True,
             )
+        )
     found_paths = expected_paths.required.copy()
     # optional paths are returned if they are found to exist
     for k, path in expected_paths.optional.items():

--- a/src/agr/redun/tasks/kgd.py
+++ b/src/agr/redun/tasks/kgd.py
@@ -43,7 +43,6 @@ KGD_OUTPUT_PLOTS_REQUIRED = [
     "PC1vDepthHWdgm.05.png",
     "PC1vInbHWdgm.05.png",
     "PCG5HWdgm.05.pdf",
-    "PlateInb.png",
     "SampDepthCR.png",
     "SampDepthHist.png",
     "SampDepth.png",
@@ -51,13 +50,14 @@ KGD_OUTPUT_PLOTS_REQUIRED = [
     "SNPCallRate.png",
     "SNPDepthHist.png",
     "SNPDepth.png",
-    "SubplateDepth.png",
-    "SubplateInb.png",
     "X2star-QQ.png",
 ]
 
 KGD_OUTPUT_PLOTS_OPTIONAL = [
     "PlateDepth.png",
+    "PlateInb.png",
+    "SubplateDepth.png",
+    "SubplateInb.png",
 ]
 
 KGD_OUTPUT_TEXT_FILES_REQUIRED = [

--- a/src/agr/redun/tasks/kgd.py
+++ b/src/agr/redun/tasks/kgd.py
@@ -43,7 +43,6 @@ KGD_OUTPUT_PLOTS_REQUIRED = [
     "PC1vDepthHWdgm.05.png",
     "PC1vInbHWdgm.05.png",
     "PCG5HWdgm.05.pdf",
-    "PlateDepth.png",
     "PlateInb.png",
     "SampDepthCR.png",
     "SampDepthHist.png",
@@ -55,6 +54,10 @@ KGD_OUTPUT_PLOTS_REQUIRED = [
     "SubplateDepth.png",
     "SubplateInb.png",
     "X2star-QQ.png",
+]
+
+KGD_OUTPUT_PLOTS_OPTIONAL = [
+    "PlateDepth.png",
 ]
 
 KGD_OUTPUT_TEXT_FILES_REQUIRED = [
@@ -126,6 +129,7 @@ def _kgd_job_spec(
             optional={
                 basename: os.path.join(out_dir, basename)
                 for basename in KGD_OUTPUT_TEXT_FILES_OPTIONAL
+                + KGD_OUTPUT_PLOTS_OPTIONAL
             },
         ),
     )
@@ -204,8 +208,9 @@ def kgd(
                 for basename in KGD_OUTPUT_BINARY_FILES_REQUIRED
             },
             plot_files={
-                basename: result.expected_files[basename]
-                for basename in KGD_OUTPUT_PLOTS_REQUIRED
+                basename: path
+                for basename in (KGD_OUTPUT_PLOTS_REQUIRED + KGD_OUTPUT_PLOTS_OPTIONAL)
+                if (path := result.expected_files.get(basename)) is not None
             },
             kgd_stdout=result.expected_files[KGD_STDOUT],
             kgd_stderr=result.expected_files[KGD_STDERR],


### PR DESCRIPTION
Run 240621_A01439_0276_AH33J5DRX5 has KGD.stdout with:
Multiple plates - plate plots not produced

I spoke with Ken.  This may be simply an anomaly introduced by a change made by lab staff.  So we decided not to investigate further.

This change makes this case non-fatal for the overall gbs_prism run.

Also, the complete list of missing files is included in the ClusterExecutorError now, instead of just the first.
