### PR TITLE
Install script to deploy as an environment module on eRI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ To see the post-processed configuration, view the output of `jsonnet $GBS_PRISM_
 
 ```
 login-1$ kinit
-login-1$ module load gbs_prism-test
-login-1$ redun run $GBS_PRISM/pipeline.py main --context-file $GBS_PRISM/eri-test.json --run 240323_A01439_0249_BH33MYDRX5
+login-1$ module load gbs_prism   # or gbs_prism-dev or gbs_prism-test
+login-1$ redun run $GBS_PRISM/pipeline.py main --run 240323_A01439_0249_BH33MYDRX5
 ```
 
 There is no need to have a local copy of the repo if simply running the pipeline from the environment module like this (but see note on development, below).

--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ gquery -t info
 
 The other environments are available via `GBS_PRISM_DEV_ENV` and `GBS_PRISM_PROD_ENV`.
 
+## Installation
+
+The eRI module installer is available as a Nix Flake app, so the install process for the end-user facing environment module and script is as follows, and should be done on `login-1` for faster Nix build.
+
+```
+login-1$ export FLAKE_URI='github:AgResearch/gbs_prism?ref=refs/tags/2.1.0'
+
+login-1$ nix run "${FLAKE_URI}#eri-install" -- --dev $FLAKE_URI
+login-1$ nix run "${FLAKE_URI}#eri-install" -- --test $FLAKE_URI
+login-1$ nix run "${FLAKE_URI}#eri-install" -- $FLAKE_URI
+```
+
+To install in your home directory (for testing prior to general release):
+
+```
+login-1$ nix run "${FLAKE_URI}#eri-install" -- --dev --home $FLAKE_URI
+login-1$ nix run "${FLAKE_URI}#eri-install" -- --test --home $FLAKE_URI
+login-1$ nix run "${FLAKE_URI}#eri-install" -- --home $FLAKE_URI
+```
+
 ## Notes
 
 1. historical_unblind has been omitted, seems not to be required

--- a/README.md
+++ b/README.md
@@ -103,7 +103,20 @@ gquery -t info
 
 The other environments are available via `GBS_PRISM_DEV_ENV` and `GBS_PRISM_PROD_ENV`.
 
-## Installation
+## Release Process
+
+`gbs_prism` is installed as an environment module on eRI in `/agr/persist/apps/eri_rocky8`.  There is an [install script](eri/install) which is usually run from the Nix flake app `eri-install`.
+
+The release process is as follows:
+
+1. Test changes using alpha version e.g. `2.1.0a1` in [pyproject.toml](pyproject.toml) and tag
+2. Install the module under your home directory (below)
+3. Verify all is well by loading the module from there
+4. Merge PR to main
+5. Update version to release e.g. `2.1.0`, push new commit to main, and tag
+6. Install the module publicly
+
+[Python packaging version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers) look like `2.1.0a1`, `2.1.0a2` for alpha releases and `2.1.0` for actual releases.
 
 The eRI module installer is available as a Nix Flake app, so the install process for the end-user facing environment module and script is as follows, and should be done on `login-1` for faster Nix build.
 
@@ -122,6 +135,8 @@ login-1$ nix run "${FLAKE_URI}#eri-install" -- --dev --home $FLAKE_URI
 login-1$ nix run "${FLAKE_URI}#eri-install" -- --test --home $FLAKE_URI
 login-1$ nix run "${FLAKE_URI}#eri-install" -- --home $FLAKE_URI
 ```
+
+To load the module from there, prepend `$MODULEPATH` with `~/modulefiles`.
 
 ## Notes
 

--- a/eri/install
+++ b/eri/install
@@ -87,11 +87,13 @@ help([==[
 
 Description
 ===========
-This module provides access to the gbs-prism pipeline.
+This module provides access to the gbs-prism pipeline, and sets up various environment variables
+for dev/test/prod as appropriate.  When using this module, the appropriate context file is automatically
+picked up from \$REDUN_CONFIG.
 
 Example
 =======
-\$ redun run \$GBS_PRISM/pipeline.py main --context-file \$GBS_PRISM/eri-test.json --run 240323_A01439_0249_BH33MYDRX5
+\$ redun run \$GBS_PRISM/pipeline.py main --run 240323_A01439_0249_BH33MYDRX5
 
 More information
 ================
@@ -101,8 +103,8 @@ More information
 depends_on("krb5cc.home")
 
 conflict("${package_base}", "${package_base}-dev", "${package_base}-test")
+conflict("gquery", "gquery-dev", "gquery-test")
 
 prepend_path("PATH", "${bin_dir}")
-setenv("GBS_PRISM", "${package_version_link}/pipeline")
 $(nix run "${nix_flake_url}#lmod-setenv" -- "${env}")
 EOF

--- a/flake.nix
+++ b/flake.nix
@@ -231,7 +231,7 @@
             esac
 
             cat <<EOF
-              setenv("GBS_PRISM_PIPELINE", "${gbs-prism-pipeline}/pipeline.py")
+              setenv("GBS_PRISM", "${gbs-prism-pipeline}")
               setenv("GBS_PRISM_EXECUTOR_CONFIG ", "${gbs-prism-pipeline}/config/eri-executor.jsonnet")
               setenv("REDUN_CONFIG ", "${gbs-prism-pipeline}/config/redun.$env")
               setenv("REDUN_DB_USERNAME", "gbs_prism_redun")
@@ -328,9 +328,6 @@
 
           packages = {
             default = gbs-prism;
-
-            # TODO remove:
-            inherit lmod-setenv-script gbs-prism-pipeline;
           };
 
           apps = {

--- a/flake.nix
+++ b/flake.nix
@@ -237,7 +237,6 @@
               setenv("REDUN_DB_USERNAME", "gbs_prism_redun")
               setenv("REDUN_DB_PASSWORD", "unused because Kerberos")
 
-              # ensure log output from gquery and geno_import goes somewhere:
               setenv("GQUERY_ROOT", pathJoin(os.getenv("HOME"), "gquery-logs"))
               setenv("GENO_ROOT", pathJoin(os.getenv("HOME"), "geno-logs"))
             EOF

--- a/flake.nix
+++ b/flake.nix
@@ -213,11 +213,15 @@
                 echo -e "\n[scheduler]\ncontext_file = $out/context/eri-$env.json" | cat $src/config/redun.$env/redun.ini - >$out/config/redun.$env/redun.ini
               done
 
-              runHook postInstall
-            '';
-
-            postFixup = ''
+              # Install just the executables we want to be on the end-user's path.
+              mkdir $out/bin
+              for prog in gquery gupdate; do
+                ln -s ${gbs-prism-python}/bin/$prog $out/bin/$prog
+              done
+              # Need to wrap redun so it can find its non-Python dependencies.
               makeWrapper ${gbs-prism-python}/bin/redun $out/bin/redun --prefix PATH : "${pkgs.lib.makeBinPath buildInputs}"
+
+              runHook postInstall
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -134,9 +134,12 @@
             poppler_utils
           ]);
 
+          pyproject = builtins.fromTOML (builtins.readFile ./pyproject.toml);
+
           gbs-prism-api = with pkgs;
             python3Packages.buildPythonPackage {
-              name = "gbs-prism-api";
+              pname = "gbs-prism-api";
+              version = pyproject.project.version;
               src = ./.;
               pyproject = true;
 
@@ -155,7 +158,8 @@
               };
             in
             pkgs.stdenv.mkDerivation {
-              name = "gbs_prism-R-scripts";
+              pname = "gbs_prism-R-scripts";
+              version = pyproject.project.version;
               src = ./R-scripts;
 
               nativeBuildInputs = [ pkgs.makeWrapper ];
@@ -185,7 +189,8 @@
           # the main pipeline.py and all the config and context files,
           # with all dependencies picked up via the path set in the redun wrapper
           gbs-prism = pkgs.stdenv.mkDerivation rec {
-            name = "gbs_prism";
+            pname = "gbs_prism";
+            version = pyproject.project.version;
             src = ./.;
 
             nativeBuildInputs = [ pkgs.makeWrapper ];
@@ -269,7 +274,8 @@
 
                   # only for development, as in production the scripts are available via the gbs-prism-api package
                   gbs-prism-python-scripts = pkgs.stdenv.mkDerivation {
-                    name = "gbs_prism-python-scripts";
+                    pname = "gbs_prism-python-scripts";
+                    version = pyproject.project.version;
                     src = ./src/agr/gbs_prism;
 
                     nativeBuildInputs = [ pkgs.makeWrapper ];

--- a/flake.nix
+++ b/flake.nix
@@ -223,8 +223,10 @@
               for prog in gquery gupdate; do
                 ln -s ${gbs-prism-python}/bin/$prog $out/bin/$prog
               done
-              # Need to wrap redun so it can find its non-Python dependencies.
-              makeWrapper ${gbs-prism-python}/bin/redun $out/bin/redun --prefix PATH : "${pkgs.lib.makeBinPath buildInputs}"
+              # Need to wrap redun so it can find its non-Python dependencies, and also
+              # so it won't break if someone plays games with PYTHONPATH and LD_LIBRARY_PATH.
+              # Note that we need the original $PATH as a suffix, to find e.g. sbatch.
+              makeWrapper ${gbs-prism-python}/bin/redun $out/bin/redun --prefix PATH : "${pkgs.lib.makeBinPath buildInputs}" --unset PYTHONPATH --unset LD_LIBRARY_PATH
 
               runHook postInstall
             '';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gbs_prism"
-version = "0.1.0a1"
+version = "2.1.0a7"
 description = "GBS Prism pipeline"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
The environment module exposes only redun, gquery, and gupdate on the path.  Everything else is hidden away.

Fixes #144 

As soon as this is merged I will actually deploy gbs_prism as a module.