### PR TITLE
Don't rename the TagCount.csv file

### DIFF
--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -216,7 +216,7 @@ def run_cohort(
         cohort_blind_dir, spec.cohort, keyfile_for_tassel, job_context=job_context
     )
 
-    tag_count = get_tag_count(fastq_to_tag_count.stdout, prefix=f"{spec.cohort.name}.")
+    tag_count = get_tag_count(fastq_to_tag_count.stdout, prefix=spec.cohort.name)
     collated_tag_count = collate_tags_reads(
         run=spec.run,
         cohort=spec.cohort.name,

--- a/src/agr/gbs_prism/redun/stage2.py
+++ b/src/agr/gbs_prism/redun/stage2.py
@@ -43,7 +43,6 @@ from agr.redun.tasks.fastq_sample import FastqSampleSpec
 from agr.redun.tasks.tassel3 import (
     fastq_name_for_tassel3,
     hap_map_dir,
-    cohort_name_tag_counts,
 )
 from agr.redun.tasks.kgd import KgdOutput, kgd_dir
 from agr.redun.tasks.unblind import (
@@ -145,7 +144,7 @@ class CohortOutput:
     collated_kgd_stats: Optional[File]
     collated_kgd_stats_unblind: Optional[File]
     gusbase_comet: Optional[File]
-    cohort_tag_counts: File
+    tag_count_unblind: File
     hap_map_files_unblind: list[File]
     kgd_text_files_unblind: dict[str, File]
     kgd_stdout_unblind: Optional[File]
@@ -217,7 +216,7 @@ def run_cohort(
         cohort_blind_dir, spec.cohort, keyfile_for_tassel, job_context=job_context
     )
 
-    tag_count = get_tag_count(fastq_to_tag_count.stdout)
+    tag_count = get_tag_count(fastq_to_tag_count.stdout, prefix=f"{spec.cohort.name}.")
     collated_tag_count = collate_tags_reads(
         run=spec.run,
         cohort=spec.cohort.name,
@@ -249,8 +248,6 @@ def run_cohort(
     tag_count_unblind = unblind_one(
         tag_count, unblind_script, spec.paths.cohort_dir(spec.cohort.name)
     )
-
-    cohort_tag_counts = cohort_name_tag_counts(tag_count_unblind, spec.cohort.name)
 
     hap_map_files_unblind = unblind_all(
         hap_map_files,
@@ -328,7 +325,7 @@ def run_cohort(
         collated_kgd_stats=collated_kgd_stats,
         collated_kgd_stats_unblind=collated_kgd_stats_unblind,
         gusbase_comet=gusbase_comet,
-        cohort_tag_counts=cohort_tag_counts,
+        tag_count_unblind=tag_count_unblind,
         hap_map_files_unblind=hap_map_files_unblind,
         kgd_text_files_unblind=kgd_text_files_unblind,
         kgd_stdout_unblind=kgd_stdout_unblind,

--- a/src/agr/gbs_prism/redun/stage3.py
+++ b/src/agr/gbs_prism/redun/stage3.py
@@ -33,7 +33,7 @@ def run_stage3(stage2: Stage2Output, out_dir: str) -> Stage3Output:
     os.makedirs(out_dir, exist_ok=True)
 
     tag_counts = sorted(
-        [cohort.cohort_tag_counts for cohort in stage2.cohorts.values()],
+        [cohort.tag_count_unblind for cohort in stage2.cohorts.values()],
         key=lambda file: file.path,
     )
 

--- a/src/agr/redun/tasks/tassel3.py
+++ b/src/agr/redun/tasks/tassel3.py
@@ -275,21 +275,15 @@ def get_fastq_to_tag_count(
 
 
 @task()
-def get_tag_count(fastqToTagCountStdout: File) -> File:
-    out_path = os.path.join(os.path.dirname(fastqToTagCountStdout.path), "TagCount.csv")
+def get_tag_count(fastqToTagCountStdout: File, prefix: str = "") -> File:
+    out_path = os.path.join(
+        os.path.dirname(fastqToTagCountStdout.path), f"{prefix}TagCount.csv"
+    )
     with open(fastqToTagCountStdout.path, "r") as in_f:
         with open(out_path, "w") as out_f:
             _ = run_catching_stderr(
                 ["get_reads_tags_per_sample"], stdin=in_f, stdout=out_f, check=True
             )
-    return File(out_path)
-
-
-@task()
-def cohort_name_tag_counts(tag_count: File, cohort: str) -> File:
-    """Rename the tag count file to include the cohort name."""
-    out_path = os.path.join(os.path.dirname(tag_count.path), f"{cohort}.TagCount.csv")
-    os.rename(tag_count.path, out_path)
     return File(out_path)
 
 

--- a/src/agr/redun/tasks/tassel3.py
+++ b/src/agr/redun/tasks/tassel3.py
@@ -277,7 +277,8 @@ def get_fastq_to_tag_count(
 @task()
 def get_tag_count(fastqToTagCountStdout: File, prefix: str = "") -> File:
     out_path = os.path.join(
-        os.path.dirname(fastqToTagCountStdout.path), f"{prefix}TagCount.csv"
+        os.path.dirname(fastqToTagCountStdout.path),
+        f"{prefix}{"." if prefix else ""}TagCount.csv",
     )
     with open(fastqToTagCountStdout.path, "r") as in_f:
         with open(out_path, "w") as out_f:


### PR DESCRIPTION
Renaming a file which redun knows about will make it unhappy.

Instead we create it in the first place with the correct name.

Fixes #162