### PR TITLE
Fix gusbase_rdata being looked up in the wrong place in KgdOutput

### DIFF
--- a/src/agr/redun/tasks/kgd.py
+++ b/src/agr/redun/tasks/kgd.py
@@ -157,7 +157,7 @@ class KgdOutput:
 
     @property
     def gusbase_rdata(self) -> Optional[File]:
-        return self.text_files.get("GUSbase.RData")
+        return self.binary_files.get("GUSbase.RData")
 
 
 def kgd_output_files(kgd_output: KgdOutput) -> list[File]:


### PR DESCRIPTION
This has been broken for ages. But was very simple, and nothing to do with lazy expressions in the end.

Fixes #165 