### PR TITLE
Restore tag limit for MergeTaxaTagCount to legacy values

### DIFF
--- a/src/agr/redun/tasks/tassel3.py
+++ b/src/agr/redun/tasks/tassel3.py
@@ -190,6 +190,10 @@ class Tassel3:
             plugin_args=[
                 "-t",
                 "y" if merge else "n",
+                "-m",
+                "600000000",
+                "-x",
+                "100000000",
             ],
             result_path=os.path.join(self.merged_tag_counts_dir, "mergedAll.cnt"),
         )


### PR DESCRIPTION
These were removed by mistake, thinking they were the same as the defaults.

Merge after parameterised config