### PR TITLE
Add demultiplex parameter merge_taxa for Tassel merge_taxa_tag_count

### DIFF
--- a/src/agr/redun/tasks/demultiplex.py
+++ b/src/agr/redun/tasks/demultiplex.py
@@ -35,6 +35,7 @@ def demultiplex(
     keyfile: File,
     job_context: JobContext,
     prefix: str = "",
+    merge_taxa: bool = False,
 ) -> DemultiplexOutput:
     consolidated_tag_count = create_consolidated_tag_count(
         work_dir=work_dir,
@@ -46,7 +47,7 @@ def demultiplex(
     merged_all_count = merge_taxa_tag_count(
         work_dir,
         consolidated_tag_count.tag_counts,
-        merge=consolidated_tag_count.merged,
+        merge=merge_taxa,
         job_context=job_context,
     )
     tag_pair = tag_count_to_tag_pair(

--- a/src/agr/redun/tasks/tag_count.py
+++ b/src/agr/redun/tasks/tag_count.py
@@ -18,10 +18,6 @@ class ConsolidatedTagCount:
     tag_counts: list[File]
     tag_count: File
 
-    # whether we had multiple parts and therefore merged them
-    # which may affect downstream processing
-    merged: bool
-
     # In the multi-part case we need to keep each stdout separately
     # since these are reported on in `collate_barcode_yields`, in which case
     # the key is a composite of the cohort name the basename of the part directory.
@@ -89,7 +85,6 @@ def _merge_results_and_counts(
     return ConsolidatedTagCount(
         tag_counts=tag_counts,
         tag_count=File(tag_count_path),
-        merged=True,
         stdout=stdout,
     )
 
@@ -150,6 +145,5 @@ def create_consolidated_tag_count(
         return ConsolidatedTagCount(
             tag_counts=fastq_to_tag_count.tag_counts,
             tag_count=tag_count,
-            merged=False,
             stdout={prefix: fastq_to_tag_count.stdout},
         )


### PR DESCRIPTION
Previously this had been incorrectly coupled with whether there was one or multiple parts returned from ramify_tassel_keyfile.