### PR TITLE
moving HWE0.05 filtered outputs to optional

### DIFF
--- a/src/agr/redun/tasks/kgd.py
+++ b/src/agr/redun/tasks/kgd.py
@@ -61,7 +61,6 @@ KGD_OUTPUT_PLOTS_OPTIONAL = [
 ]
 
 KGD_OUTPUT_TEXT_FILES_REQUIRED = [
-    "HeatmapOrderHWdgm.05.csv",
     "SampleStats.csv",
     "SampleStatsRawCombined.csv",
     "SampleStatsRaw.csv",
@@ -71,6 +70,7 @@ KGD_OUTPUT_TEXT_FILES_REQUIRED = [
 KGD_OUTPUT_TEXT_FILES_OPTIONAL = [
     "HighRelatedness.csv",
     "HighRelatedness.split.csv",
+    "HeatmapOrderHWdgm.05.csv",
     "GHW05.csv",
     "GHW05-Inbreeding.csv",
     "GHW05-long.csv",


### PR DESCRIPTION
After filtering, sometimes there are no samples are left (failed library), we still need things to finish processing however.