### PR TITLE
Add pygraphviz for redun viz

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,7 @@
               jsonnet
               pdf2image
               pydantic
+              pygraphviz # for redun viz
               flakePkgs.gquery
               flakePkgs.geno-import
               flakePkgs.redun


### PR DESCRIPTION
While this PR addresses the missing Python dependency, there may be an underlying issue with the visualization graph.  I saw errors like this:
```
login-1> redun viz --format png --output ~/Downloads/redun-playpen-viz 21927dea
Traceback (most recent call last):
  File "/nix/store/bwwn2559b7jv1p9q8s6791a8cphywwlw-python3-3.12.10-env/lib/python3.12/site-packages/pygraphviz/agraph.py", line 1857, in __new__
    nh = gv.agnode(graph.handle, n.encode(graph.encoding), _Action.find)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/bwwn2559b7jv1p9q8s6791a8cphywwlw-python3-3.12.10-env/lib/python3.12/site-packages/pygraphviz/graphviz.py", line 97, in agnode
    return _graphviz.agnode(g, name, createflag)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'agnode: no key'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/bwwn2559b7jv1p9q8s6791a8cphywwlw-python3-3.12.10-env/lib/python3.12/site-packages/pygraphviz/agraph.py", line 498, in add_edge
    uh = Node(self, u).handle
         ^^^^^^^^^^^^^
  File "/nix/store/bwwn2559b7jv1p9q8s6791a8cphywwlw-python3-3.12.10-env/lib/python3.12/site-packages/pygraphviz/agraph.py", line 1859, in __new__
    raise KeyError(f"Node {n} not in graph.")
KeyError: "Node (Value(hash='d6b9dd45', value=<redun_psij.job_attributes.JobContext object at 0x7fe72e14a0f0>), 'f554890dcf78f869893459fa736085a13796d4da') not in graph."
```

I did not take the time to investigate this further, since I saw redun viz working OK in a simpler workflow, so I don't think it's a library dependency problem.

Fixes #199
