### PR TITLE
Make get_unblind_script task uncacheable

### DIFF
--- a/src/agr/redun/tasks/unblind.py
+++ b/src/agr/redun/tasks/unblind.py
@@ -48,12 +48,9 @@ def get_unblind_script(
             outfile=out_f,
         ).run()
 
+    # even if file is the same, redun won't think so unless we reset the mtime
     if previous is not None:
-        latest = get_file_hash_times(out_path)
-        assert latest is not None
-        if latest.hash == previous.hash:
-            # file is the same, but redun won't think so unless we reset the mtime
-            os.utime(out_path, ns=(previous.atime_ns, previous.mtime_ns))
+        previous.preserve_mtime_if_unchanged()
 
     return File(out_path)
 

--- a/src/agr/util/path.py
+++ b/src/agr/util/path.py
@@ -90,9 +90,15 @@ def expand(path: str) -> str:
 
 @dataclass
 class FileHashTimes:
+    path: str
     hash: str
     atime_ns: int
     mtime_ns: int
+
+    def preserve_mtime_if_unchanged(self):
+        current = get_file_hash_times(self.path)
+        if current is not None and current.hash == self.hash:
+            os.utime(self.path, ns=(current.atime_ns, self.mtime_ns))
 
 
 def get_file_hash_times(path: str):
@@ -105,7 +111,9 @@ def get_file_hash_times(path: str):
             h.update(content)
             hash = h.hexdigest()
 
-        return FileHashTimes(hash=hash, atime_ns=s.st_atime_ns, mtime_ns=s.st_mtime_ns)
+        return FileHashTimes(
+            path=path, hash=hash, atime_ns=s.st_atime_ns, mtime_ns=s.st_mtime_ns
+        )
 
     except OSError:
         return None


### PR DESCRIPTION
We can't know ahead of time whether we need a new unblind script, so we always fetch it, and rely on redun file comparison to not trigger downstream processing if it hasn't in fact changed.

Fixes #195